### PR TITLE
Update LaserStream documentation to clarify historical replay capabil…

### DIFF
--- a/laserstream.mdx
+++ b/laserstream.mdx
@@ -129,7 +129,7 @@ For applications that need to catch up on historical data or implement fault-tol
 
 | Feature | LaserStream | Standard Solana RPC | Yellowstone gRPC |
 |---------|-------------|---------------------|------------------|
-| **Historical replay** | ✅ Up to 3000 slots | ❌ Not available | ❌ Limited |
+| **Historical replay** | ✅ Up to 3000 slots (approx. 20 minutes) | ❌ Not available | ❌ Limited |
 | **Auto-reconnect** | ✅ Built-in | ❌ Manual implementation | ❌ Manual implementation |
 | **Multi-node failover** | ✅ Automatic | ❌ Manual implementation | ❌ Manual implementation |
 | **WebSocket support** | 🔜 Coming soon | ✅ Standard | ❌ Not available |

--- a/laserstream/historical-replay.mdx
+++ b/laserstream/historical-replay.mdx
@@ -109,12 +109,12 @@ const request = {
 
 ## Limitations
 
-- **Replay Window**: Currently, you can replay data from up to 3000 slots in the past.
+- **Replay Window**: Currently, you can replay data from up to 3000 slots in the past (approximately 20 minutes of blockchain activity).
 - **Data Availability**: Some very old historical data may not be available for replay.
 
 ## Best Practices
 
-1. **Use Recent Slots**: When specifying a `fromSlot`, ensure it falls within the replay window (currently 3000 slots).
+1. **Use Recent Slots**: When specifying a `fromSlot`, ensure it falls within the replay window (currently 3000 slots or about 20 minutes).
 2. **Handle High Volumes**: During catch-up, you may receive data at a faster rate than during real-time streaming.
 3. **Set Appropriate Filters**: To minimize the amount of data during replay, use specific filters.
 4. **Monitor Reconnections**: The SDK handles reconnections automatically, but it's good practice to log when they occur.


### PR DESCRIPTION
…ities, specifying that up to 3000 slots corresponds to approximately 20 minutes of blockchain activity.