### PR TITLE
Fix token accounts link

### DIFF
--- a/rpc/guides/gettokenaccountsbyowner.mdx
+++ b/rpc/guides/gettokenaccountsbyowner.mdx
@@ -4,7 +4,7 @@ sidebarTitle: "getTokenAccountsByOwner"
 description: "Learn getTokenAccountsByOwner use cases, code examples, request parameters, response structure, and tips."
 ---
 
-The [`getTokenAccountsByOwner`](https://www.helius.dev/docs/api-reference/rpc/http/gettokenaccountsbyowner) RPC method is used to retrieve all SPL [Token accounts]((https://www.helius.dev/blog/how-to-get-token-holders-on-solana)) owned by a specific public key. This is a fundamental method for wallets and applications that need to display a user's token holdings or interact with their various token accounts.
+The [`getTokenAccountsByOwner`](https://www.helius.dev/docs/api-reference/rpc/http/gettokenaccountsbyowner) RPC method is used to retrieve all SPL [Token accounts](https://www.helius.dev/blog/how-to-get-token-holders-on-solana) owned by a specific public key. This is a fundamental method for wallets and applications that need to display a user's token holdings or interact with their various token accounts.
 
 You must filter the query by either a specific token `mint` or a `programId` (e.g., the SPL Token Program or Token-2022 Program).
 


### PR DESCRIPTION
## Summary
- fix Token accounts link in gettokenaccountsbyowner guide

## Testing
- `mintlify dev` *(fails: command not found)*
- `mintlify build` *(fails: command not found)*