### PR TITLE
Fix doc formatting and spelling error

### DIFF
--- a/openapi/openapi-definition.yaml
+++ b/openapi/openapi-definition.yaml
@@ -2183,7 +2183,7 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/TokenSwap'
-          description: 'The inner swaps occuring to make this swap happen. Eg. a swap of wSOL <-> USDC may be make of multiple swaps from wSOL <-> DUST, DUST <-> USDC'
+          description: 'The inner swaps occurring to make this swap happen. Eg. a swap of wSOL <-> USDC may be make of multiple swaps from wSOL <-> DUST, DUST <-> USDC'
 
     TokenSwap:
       type: object

--- a/openapi/webhooks.yaml
+++ b/openapi/webhooks.yaml
@@ -1643,7 +1643,7 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/TokenSwap'
-          description: 'The inner swaps occuring to make this swap happen. Eg. a swap of wSOL <-> USDC may be make of multiple swaps from wSOL <-> DUST, DUST <-> USDC'
+          description: 'The inner swaps occurring to make this swap happen. Eg. a swap of wSOL <-> USDC may be make of multiple swaps from wSOL <-> DUST, DUST <-> USDC'
 
     TokenSwap:
       type: object

--- a/quickstart.mdx
+++ b/quickstart.mdx
@@ -31,7 +31,7 @@ We'll use Node.js for this example. If you don't have it yet, you can download i
 <Step title="Create a new file">
 ```bash
 touch fetchRandomNFT.js
-````
+```
 </Step>
 <Step title="Copy the following code into the file">
 ```javascript fetchRandomNFT.js
@@ -68,7 +68,7 @@ async function fetchRandomNFT() {
 }
 
 fetchRandomNFT();
-````
+```
 </Step>
 <Step title="Replace the API key">
   Replace `YOUR_API_KEY` with your API key.
@@ -76,7 +76,7 @@ fetchRandomNFT();
 <Step title="Run the code">
 ```bash
 node fetchRandomNFT.js
-````
+```
 </Step>
 <Step title="Success!">
   Success! You should see the ID, name, symbol, and image of a random NFT owned by the address `86xCn…o2MMY` in your terminal.
@@ -105,4 +105,3 @@ Explore more quickstarts to get the most out of Helius:
     Subscribe to on-chain activity using Webhooks.
   </Card>
 </CardGroup>
-````


### PR DESCRIPTION
## Summary
- fix fenced code blocks in Quickstart doc
- correct spelling of "occurring" in OpenAPI specs

## Testing
- `git status --short`