### PR TITLE
docs: add attribution section to LaserStream documentation, noting it…

### DIFF
--- a/laserstream.mdx
+++ b/laserstream.mdx
@@ -173,3 +173,7 @@ For applications that need to catch up on historical data or implement fault-tol
 ## Next Steps
 
 For more information or to request access to the LaserStream private beta, join the discussion on our [Discord](https://discord.com/invite/6GXdee3gBj) or [Telegram](https://t.me/helius_help).
+
+## Attribution
+
+LaserStream is a custom fork of [Richat](https://github.com/lamports-dev/richat) project.


### PR DESCRIPTION
…s origin as a fork of the Richat project