### PR TITLE
Remove outdated data from limitations

### DIFF
--- a/laserstream/historical-replay.mdx
+++ b/laserstream/historical-replay.mdx
@@ -63,7 +63,6 @@ const subscriptionRequest: SubscribeRequest = {
 ## Limitations
 
 - **Replay Window**: Currently, you can replay data from up to 3000 slots in the past (approximately 20 minutes of blockchain activity).
-- **Data Availability**: Some very old historical data may not be available for replay.
 
 ## Best Practices
 


### PR DESCRIPTION
The line `- **Data Availability**: Some very old historical data may not be available for replay.` was removed from the `Limitations` section within `laserstream/historical-replay.mdx`.

*   The initial request targeted `laserstream.mdx`, but the specific content was found in `laserstream/historical-replay.mdx`.
*   The removal was performed to streamline the `Limitations` section, addressing prior feedback that identified this content as confusing.
*   The `Limitations` section in `laserstream/historical-replay.mdx` now exclusively features the `Replay Window` limitation.