### PR TITLE
Update LaserStream vs Dedicated Nodes documentation to clarify rate l…

### DIFF
--- a/laserstream/laserstream-vs-dedicated-nodes.mdx
+++ b/laserstream/laserstream-vs-dedicated-nodes.mdx
@@ -29,8 +29,8 @@ LaserStream comes with a Pro plan subscription that includes additional platform
 
 | Feature | LaserStream (Pro Plan) | Dedicated Nodes |
 |---------|-------------|-----------------|
-| **Rate Limits** | ⚠️ **Shared rate limits** | ✅ **Isolated rate limits** |
-| **Credit Isolation** | ⚠️ **Shared credits** | ✅ **Dedicated credit pool** |
+| **Rate Limits** | ⚠️ **Has rate limits** | ✅ **No rate limits** |
+| **Credit Usage** | ⚠️ **Has credits** | ✅ **No credits** |
 | **sendTransaction** | ✅ **Optimized landing rates** | ❌ **Poor landing rates** |
 | **Archival Data Access** | ✅ **Available via shared plan** | ❌ **Not available** |
 | **Platform Features** | ✅ **APIs, webhooks included** | ❌ **Requires separate shared plan** |


### PR DESCRIPTION
…imits and credit usage. Change descriptions to reflect that LaserStream has rate limits and credits, while Dedicated Nodes offer no limits or credits. Enhance overall comparison for better understanding of features.