### PR TITLE
Update rate limits in billing and sender documentation to reflect inc…

### DIFF
--- a/billing/plans-and-rate-limits.mdx
+++ b/billing/plans-and-rate-limits.mdx
@@ -133,10 +133,10 @@ Some endpoints have different limits due to their computational requirements:
       <td>
         <code>Sender</code>
       </td>
-      <td>1 call/sec</td>
-      <td>1 call/sec</td>
-      <td>1 call/sec</td>
-      <td>1 call/sec</td>
+      <td>3 calls/sec</td>
+      <td>3 calls/sec</td>
+      <td>3 calls/sec</td>
+      <td>3 calls/sec</td>
     </tr>
     <tr>
       <td>

--- a/sending-transactions/sender.mdx
+++ b/sending-transactions/sender.mdx
@@ -20,7 +20,7 @@ Helius Sender is a specialized service for ultra-low latency transaction submiss
     Available on all plans without consuming API credits
   </Card>
   <Card title="High Throughput" icon="gauge-high">
-    Default 1 TPS, contact us for higher limits
+    Default 3 TPS, contact us for higher limits
   </Card>
 </CardGroup>
 
@@ -544,7 +544,7 @@ For optimal latency, consider co-locating with Helius servers in Frankfurt or Lo
 
 ## Rate Limits and Scaling
 
-- **Default Rate Limit**: 1 transaction per second
+- **Default Rate Limit**: 3 transactions per second
 - **No Credit Usage**: Sender transactions don't consume API credits from your plan
 
 ## Support and Scaling


### PR DESCRIPTION
…reased throughput from 1 TPS to 3 TPS. Enhance clarity on default rate limits for better user understanding.