### PR TITLE
Add LaserStream Data Metering note to billing documentation, clarifyi…

### DIFF
--- a/billing/plans-and-rate-limits.mdx
+++ b/billing/plans-and-rate-limits.mdx
@@ -355,6 +355,10 @@ Some endpoints have special restrictions due to their computational requirements
   </tbody>
 </table>
 
+<Note>
+**LaserStream Data Metering**: Billing is based on **uncompressed** gRPC message size, not the compressed data your client receives. Typical sizes: Block (~4MB), Account (~373B), Transaction (~662B).
+</Note>
+
 <Tabs>
 
   <Tab title="Transaction Submission">


### PR DESCRIPTION
…ng billing based on uncompressed gRPC message size.