### PR TITLE
Fix banner links in documentation: Updated URLs in the banner content…

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -26,7 +26,7 @@
     "default": "dark"
   },
   "banner": {
-    "content": "LaserStream and Sender are now live! Experience ultra-fast data streaming and optimized transaction sending. [Learn about LaserStream](docs/laserstream) | [Learn about Sender](docs/sending-transactions/sender)",
+    "content": "LaserStream and Sender are now live! Experience ultra-fast data streaming and optimized transaction sending. [Learn about LaserStream](/docs/laserstream) | [Learn about Sender](/docs/sending-transactions/sender)",
     "dismissible": true
   },
   "contextual": {


### PR DESCRIPTION
… to use absolute paths for LaserStream and Sender, ensuring proper navigation for users.