### PR TITLE
Enhance LaserStream and billing documentation with new add-on details

### DIFF
--- a/billing/plans-and-rate-limits.mdx
+++ b/billing/plans-and-rate-limits.mdx
@@ -92,6 +92,10 @@ Access our RPC node fleet across **Pittsburgh, Newark, Salt Lake City, Los Angel
   </tbody>
 </table>
 
+<Note>
+  If you're on a legacy plan, see the [Legacy Plan Details](#legacy-plans) section below.
+</Note>
+
 <CardGroup cols={2}>
   <Card
     title="Get Started Today"
@@ -109,9 +113,21 @@ Access our RPC node fleet across **Pittsburgh, Newark, Salt Lake City, Los Angel
   </Card>
 </CardGroup>
 
-<Note>
-  If you're on a legacy plan, see the [Legacy Plan Details](#legacy-plans) section below.
-</Note>
+## Add-On Plans
+
+### LaserStream Plus
+
+<Card title="LaserStream 50TB Add-On" icon="bolt">
+  **$2,500/month** - Supercharge your Professional plan for ultra-high throughput streaming
+  
+  **How it works:**
+  - Professional plan: Pay **3 credits per 0.1MB** for all LaserStream usage
+  - Add-on provides **50 TB included bandwidth** each month  
+  - After your 50 TB runs out: Pay **1 credit per 0.1MB** (67% cheaper than Professional's 3 credits)
+  - All other Professional plan features included
+  
+  **Perfect for:** High-frequency trading bots, portfolio trackers, DEX aggregators, and real-time analytics platforms.
+</Card>
 
 ---
 
@@ -377,7 +393,10 @@ Some endpoints have special restrictions due to their computational requirements
 </table>
 
 <Note>
-**LaserStream Data Metering**: Billing is based on **uncompressed** gRPC message size, not the compressed data your client receives. Typical sizes for updates: Block (~4MB), Account (~0.0004MB), Transaction (~0.0006MB).
+**LaserStream Billing Guide**: 
+- **Professional Plan**: Pay 3 credits per 0.1MB for all LaserStream usage (no included bandwidth).
+- **LaserStream Plus Add-on**: Includes 50 TB monthly bandwidth. After that, pay only 1 credit per 0.1MB (67% savings).
+- **Data Size**: Billing based on uncompressed gRPC message size. Typical sizes: Block (~4MB), Account (~0.0004MB), Transaction (~0.0006MB).
 
 **Webhook Billing**: You are charged 1 credit when Helius processes and sends a webhook event to your endpoint. This charge applies regardless of whether your endpoint successfully receives or processes the webhook.
 </Note>

--- a/laserstream.mdx
+++ b/laserstream.mdx
@@ -145,8 +145,26 @@ LaserStream is available in multiple regions worldwide for optimal performance. 
 LaserStream uses your Helius API key for authentication. You can obtain your API key from the [Helius Dashboard](https://dashboard.helius.dev/). Your API key serves as both your authentication token and grants access to LaserStream's enhanced features.
 
 <Note>
-**Plan Requirement**: LaserStream is currently available for **Professional plan** subscribers. To access LaserStream, please ensure your Helius account is on a Professional plan. You can upgrade your plan in the [Helius Dashboard](https://dashboard.helius.dev/).
+**Plan Requirement**: LaserStream is available for **Professional plan** subscribers ($999/month). Professional plan users pay 3 credits per 0.1MB for all LaserStream usage. You can upgrade your plan in the [Helius Dashboard](https://dashboard.helius.dev/).
 </Note>
+
+### Need High-Volume Streaming? LaserStream Plus Add-On
+
+If you're building applications that consume massive amounts of real-time Solana data, the LaserStream Plus add-on transforms your costs:
+
+<CardGroup cols={1}>
+  <Card title="From Pay-Per-Use to 50 TB Included" icon="chart-line">
+    **Professional Plan**: Pay 3 credits per 0.1MB from first byte  
+    **LaserStream Plus**: Get 50 TB included monthly, then only 1 credit per 0.1MB
+    
+    **$2,500/month** - Perfect for trading bots, real-time analytics, and portfolio trackers processing continuous market data.
+  </Card>
+</CardGroup>
+
+**When to consider LaserStream Plus:**
+- Your app processes full market data streams (all DEX trades, NFT sales, etc.)
+- You're building high-frequency trading systems
+- You need 24/7 account monitoring across thousands of wallets  
 
 ## Getting Started
 


### PR DESCRIPTION
- Updated LaserStream section to include pricing and features for the new LaserStream Plus add-on, offering 50 TB of included bandwidth for $2,500/month.
- Clarified billing structure for both Professional plan and LaserStream Plus, emphasizing cost savings and use cases.
- Added a note regarding legacy plans in the billing documentation for better user guidance.