### PR TITLE
Add warnings for unstable RPC methods in blocksubscribe and votesubsc…

### DIFF
--- a/api-reference/rpc/websocket/blocksubscribe.mdx
+++ b/api-reference/rpc/websocket/blocksubscribe.mdx
@@ -10,6 +10,10 @@ description: "Subscribe to receive notification anytime a new block is `confirme
 This subscription is considered **unstable** and is only available if the validator was started with the `--rpc-pubsub-enable-block-subscription` flag. The format of this subscription may change in the future.
 </Note>
 
+<Warning>
+This is an unstable RPC method that **Helius does not support**. This documentation is provided for reference only.
+</Warning>
+
 ## Endpoints
 
 Websockets are available on mainnet and devnet with the following URLs:

--- a/api-reference/rpc/websocket/votesubscribe.mdx
+++ b/api-reference/rpc/websocket/votesubscribe.mdx
@@ -10,6 +10,10 @@ description: "Subscribe to receive notification anytime a new vote is observed i
 This subscription is unstable and only available if the validator was started with the `--rpc-pubsub-enable-vote-subscription` flag. The format of this subscription may change in the future.
 </Note>
 
+<Warning>
+This is an unstable RPC method that **Helius does not support**. This documentation is provided for reference only.
+</Warning>
+
 ## Endpoints
 
 Websockets are available on mainnet and devnet with the following URLs:


### PR DESCRIPTION
…ribe documentation

- Included a warning in both `blocksubscribe.mdx` and `votesubscribe.mdx` indicating that these RPC methods are unstable and not supported by Helius. This documentation is provided for reference only.