### PR TITLE
Add ANY option to TransactionType enum in webhooks.yaml

### DIFF
--- a/openapi/webhooks.yaml
+++ b/openapi/webhooks.yaml
@@ -518,6 +518,7 @@ components:
     TransactionType:
       type: string
       enum:
+      - ANY
       - ACCEPT_ESCROW_ARTIST
       - ACCEPT_ESCROW_USER
       - ACCEPT_PROPOSAL


### PR DESCRIPTION
- Introduced a new value `ANY` to the `TransactionType` enum for enhanced flexibility in transaction handling.