### PR TITLE
Clarify LaserStream gRPC billing details

### DIFF
--- a/billing/plans-and-rate-limits.mdx
+++ b/billing/plans-and-rate-limits.mdx
@@ -362,7 +362,7 @@ Some endpoints have special restrictions due to their computational requirements
     <tr>
       <td><strong>LaserStream gRPC</strong></td>
       <td style={{textAlign: 'center'}}>3</td>
-      <td>Per 0.1MB of streamed data</td>
+      <td>Per 0.1MB of streamed data (uncompressed)</td>
     </tr>
     <tr>
       <td><strong>LaserStream 50TB Add-on</strong></td>


### PR DESCRIPTION
- Updated the billing documentation for LaserStream gRPC to specify that the charge is "Per 0.1MB of streamed data (uncompressed)" for better accuracy and understanding.