### PR TITLE
Update sendTransaction cost to 1 credit

### DIFF
--- a/api-reference/endpoints.mdx
+++ b/api-reference/endpoints.mdx
@@ -30,9 +30,7 @@ These URLs are specifically masked and IP rate-limited at 5 TPS, making them saf
 **Deprecated**: The staked endpoint (`staked.helius-rpc.com`) has been deprecated. Use the regular endpoint instead (`mainnet.helius-rpc.com`) which now uses staked connections by default.
 </Warning>
 
-Staked connections are now the default for all transactions sent through Helius standard endpoints. This change provides:
-
-- **Cost**: 10 credits per `sendTransaction` request (reduced from 50 credits)
+- **Cost**: 1 credit per `sendTransaction` request (reduced from 50 credits)
 - **Automatic optimization**: All transactions are sent over optimized network infrastructure (Asia, Europe, and North America)
 - **Higher landing rates**: Guaranteed access to staked connections during market congestion
 - **No code changes required**: Existing applications automatically benefit from staked connections

--- a/billing/plans-and-rate-limits.mdx
+++ b/billing/plans-and-rate-limits.mdx
@@ -433,7 +433,7 @@ Some endpoints have special restrictions due to their computational requirements
         </tr>
         <tr>
           <td><strong>Staked Connections</strong></td>
-          <td style={{textAlign: 'center'}}>10</td>
+          <td style={{textAlign: 'center'}}>1</td>
           <td>Highest reliability (default)</td>
         </tr>
       </tbody>

--- a/changelog.mdx
+++ b/changelog.mdx
@@ -125,7 +125,7 @@ Want to stay updated? Join our [Discord community](https://discord.com/invite/6G
 
   **What's Changed:**
   - **Staked Connections Default**: Transactions sent through Helius now automatically use staked connections by default, providing you with the highest transaction landing rates and optimizing for speed and reliability. No code changes required.
-  - **Pricing Update**: Staked connection pricing decreased from 50 to 10 credits per transaction, making it more cost-effective to use our premium transaction infrastructure.
+  - **Pricing Update**: Staked connection pricing decreased from 50 to 1 credit per transaction, making it more cost-effective to use our premium transaction infrastructure.
 
   **Endpoint Changes:**
   - **Staked Endpoint**: The dedicated staked endpoint (`staked.helius-rpc.com`) is being phased out in favor of the regular endpoint which now uses staked connections by default. You can continue using the staked endpoint for now, but we recommend switching to the regular endpoint (`mainnet.helius-rpc.com`) for the best experience.


### PR DESCRIPTION
## Summary
- update sendTransaction cost to 1 credit in API Endpoints page
- adjust Staked Connections credit cost in billing page
- update changelog entry

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_688abbb35ed08326b472ce2856f65db9