### PR TITLE
Remove reference to "Unstaked Connections" from billing documentation…

### DIFF
--- a/billing/plans-and-rate-limits.mdx
+++ b/billing/plans-and-rate-limits.mdx
@@ -427,11 +427,6 @@ Some endpoints have special restrictions due to their computational requirements
           <td>Ultra-low latency submission</td>
         </tr>
         <tr>
-          <td><strong>Unstaked Connections</strong></td>
-          <td style={{textAlign: 'center'}}>1</td>
-          <td>May be unreliable during congestion</td>
-        </tr>
-        <tr>
           <td><strong>Staked Connections</strong></td>
           <td style={{textAlign: 'center'}}>1</td>
           <td>Highest reliability (default)</td>


### PR DESCRIPTION
… to streamline information on connection types.