### PR TITLE
Update API documentation for getSignaturesForAsset endpoint to clarif…

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -390,7 +390,6 @@
                   "api-reference/das/getassetsbygroup",
                   "api-reference/das/getassetsbyowner",
                   "api-reference/das/getnfteditions",
-                  "api-reference/das/getsignaturesforasset",
                   "api-reference/das/gettokenaccounts",
                   "api-reference/das/searchassets"
                 ]
@@ -416,6 +415,7 @@
                 "icon": "arrows-to-circle",
                 "pages": [
                   "api-reference/zk-compression",
+                  "api-reference/das/getsignaturesforasset",
                   "api-reference/zk-compression/getcompressedaccount",
                   "api-reference/zk-compression/getcompressedaccountproof",
                   "api-reference/zk-compression/getcompressedaccountsbyowner",

--- a/openapi/das-api/getSignaturesForAsset.yaml
+++ b/openapi/das-api/getSignaturesForAsset.yaml
@@ -30,12 +30,13 @@ paths:
         - RPC
       summary: getSignaturesForAsset
       description: |
-        Retrieve a complete chronological history of all transactions involving a specific Solana NFT or token.
-        This transaction history API returns an ordered list of transaction signatures and operation types
-        that affected a particular digital asset on the Solana blockchain, enabling applications to track
+        Retrieve a complete chronological history of all transactions involving a specific compressed NFT (cNFT).
+        This specialized method returns an ordered list of transaction signatures and operation types
+        that affected a particular compressed digital asset on the Solana blockchain, enabling applications to track
         the full ownership history, creation events, transfers, listings, sales, and other operations.
-        Essential for marketplace provenance verification, wallet transaction history, and analytics 
-        platforms tracking the lifecycle of NFTs and tokens across the Solana ecosystem.
+        
+        **Note:** This method is specifically designed for compressed NFTs. For regular NFTs, use `getSignaturesForAddress` instead.
+        This specialized endpoint was added because the standard `getSignaturesForAddress` method doesn't work with compressed NFTs.
       operationId: rpc
       security:
         - ApiKeyQuery: []


### PR DESCRIPTION
…y its use for compressed NFTs and restore its reference in the documentation structure.