### PR TITLE
docs: update sender tps limit to 6

### DIFF
--- a/billing/plans-and-rate-limits.mdx
+++ b/billing/plans-and-rate-limits.mdx
@@ -202,10 +202,10 @@ Some endpoints have special restrictions due to their computational requirements
       <tbody>
         <tr>
           <td><code>Sender</code></td>
-          <td>3/sec</td>
-          <td>3/sec</td>
-          <td>3/sec</td>
-          <td>3/sec</td>
+          <td>6/sec</td>
+          <td>6/sec</td>
+          <td>6/sec</td>
+          <td>6/sec</td>
         </tr>
         <tr>
           <td><code>sendTransaction</code></td>

--- a/sending-transactions/sender.mdx
+++ b/sending-transactions/sender.mdx
@@ -596,7 +596,7 @@ For optimal latency, consider co-locating with Helius servers in Frankfurt or Lo
 
 ## Rate Limits and Scaling
 
-- **Default Rate Limit**: 3 transactions per second
+- **Default Rate Limit**: 6 transactions per second
 - **No Credit Usage**: Sender transactions don't consume API credits from your plan
 
 ## Support and Scaling


### PR DESCRIPTION
## Summary
- update Sender special endpoint rate limit to 6 TPS
- clarify Sender default rate limit in guide

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_6892b29524788326a92f2249c9a62c44