### PR TITLE
docs: note getAsset price cache

### DIFF
--- a/api-reference/das/getasset.mdx
+++ b/api-reference/das/getasset.mdx
@@ -2,3 +2,7 @@
 title: "getAsset"
 openapi: "/openapi/das-api/getAsset.yaml POST /"
 ---
+
+<Callout type="info">
+  Price data returned by `getAsset` is cached for up to 60 seconds and may be up to 60 seconds old.
+</Callout>

--- a/das/get-nfts.mdx
+++ b/das/get-nfts.mdx
@@ -23,6 +23,10 @@ The Helius Digital Asset Standard (DAS) API provides powerful tools for reading 
 
 ## Price Data for Jupiter Verified Tokens
 
+<Callout type="info">
+  Price data returned by `getAsset` is cached for up to 60 seconds and may be up to 60 seconds old.
+</Callout>
+
 ```typescript
 const fetchTokenPriceData = async () => {
   const response = await fetch("https://mainnet.helius-rpc.com/?api-key=YOUR_API_KEY", {


### PR DESCRIPTION
## Summary
- clarify that `getAsset` price data is cached for up to 60 seconds on its API reference page
- mention the 60-second cache on the *Get Assets* guide

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_6893e25d31b88326afaa8ee2c00641e6