### PR TITLE
Update priority fee FAQ for clarity and accuracy

### DIFF
--- a/faqs/priority-fee.mdx
+++ b/faqs/priority-fee.mdx
@@ -32,7 +32,7 @@ See the [Priority Fee API guide](/priority-fee-api) for detailed explanations of
 <Accordion title="How do I calculate the total cost of priority fees?">
 **Formula**: Total priority fee = Price per compute unit × Compute units consumed
 
-Use the [Priority Fee API](/priority-fee-api) to get real-time estimates for your specific transaction instead of manual calculations. The API accounts for current network conditions and transaction complexity.
+Use the [Priority Fee API](/priority-fee-api) to get real time estimates for your specific transaction instead of manual calculations. The API accounts for current network conditions and transaction complexity.
 </Accordion>
 
 ---


### PR DESCRIPTION
- Revised the wording in the "How do I calculate the total cost of priority fees?" section to change "real-time" to "real time" for consistency in terminology.