### PR TITLE
Fix LS dollar amount display

### DIFF
--- a/billing/plans-and-rate-limits.mdx
+++ b/billing/plans-and-rate-limits.mdx
@@ -448,7 +448,7 @@ Some endpoints have special restrictions due to their computational requirements
 **LaserStream Billing Guide**: 
 - **Developer & Business Plans**: Pay 3 credits per 0.1 MB for all LaserStream devnet usage.
 - **Professional Plan**: Pay 3 credits per 0.1 MB for all LaserStream devnet and mainnet usage.
-- **LaserStream Plus Add-on**: Available in 50TB ($2,500), 100TB ($4,500), 150TB ($6,500), 200TB ($8,500), or 250TB ($10,500) tiers. After included data runs out, pay only 2 credits per 0.1 MB (33% savings).
+- **LaserStream Plus Add-on**: Available in 50TB (\$2,500), 100TB (\$4,500), 150TB (\$6,500), 200TB (\$8,500), or 250TB (\$10,500) tiers. After included data runs out, pay only 2 credits per 0.1 MB (33% savings).
 - **Data Size**: Billing based on uncompressed gRPC message size. Typical sizes: Block (~4MB), Account (~0.0004MB), Transaction (~0.0006MB).
 </Note>
 


### PR DESCRIPTION
Dollar chars in `billing/plans-and-rate-limits.mdx` were wrongly interpreted as Latex expressions. This PR fixes it by escaping them.

Testing: Go to `/billing/plans-and-rate-limits` and scroll down to `LaserStream Plus Add-on: Available in [...]`