### PR TITLE
Add Los Angeles endpoint to LaserStream documentation

### DIFF
--- a/laserstream.mdx
+++ b/laserstream.mdx
@@ -123,6 +123,7 @@ LaserStream is available in multiple regions worldwide for optimal performance. 
 | **ewr** | Newark, NJ (near New York) | `https://laserstream-mainnet-ewr.helius-rpc.com` |
 | **pitt** | Pittsburgh, US (Central) | `https://laserstream-mainnet-pitt.helius-rpc.com` |
 | **slc** | Salt Lake City, US (West Coast) | `https://laserstream-mainnet-slc.helius-rpc.com` |
+| **lax** | Los Angeles, US (West Coast) | `https://laserstream-mainnet-lax.helius-rpc.com` |
 | **ams** | Amsterdam, Europe | `https://laserstream-mainnet-ams.helius-rpc.com` |
 | **fra** | Frankfurt, Europe | `https://laserstream-mainnet-fra.helius-rpc.com` |
 | **tyo** | Tokyo, Asia | `https://laserstream-mainnet-tyo.helius-rpc.com` |

--- a/laserstream/grpc.mdx
+++ b/laserstream/grpc.mdx
@@ -29,6 +29,7 @@ LaserStream is available in multiple regions worldwide. Choose the endpoint clos
 | **ewr** | Newark, NJ (near New York) | `https://laserstream-mainnet-ewr.helius-rpc.com` |
 | **pitt** | Pittsburgh, US (Central) | `https://laserstream-mainnet-pitt.helius-rpc.com` |
 | **slc** | Salt Lake City, US (West Coast) | `https://laserstream-mainnet-slc.helius-rpc.com` |
+| **lax** | Los Angeles, US (West Coast) | `https://laserstream-mainnet-lax.helius-rpc.com` |
 | **ams** | Amsterdam, Europe | `https://laserstream-mainnet-ams.helius-rpc.com` |
 | **fra** | Frankfurt, Europe | `https://laserstream-mainnet-fra.helius-rpc.com` |
 | **tyo** | Tokyo, Asia | `https://laserstream-mainnet-tyo.helius-rpc.com` |


### PR DESCRIPTION
- Included the new Los Angeles (lax) endpoint in both laserstream.mdx and laserstream/grpc.mdx files for improved regional coverage.