### PR TITLE
Update rpc methods with changedSinceSlot

### DIFF
--- a/api-reference/rpc/http/getaccountinfo.mdx
+++ b/api-reference/rpc/http/getaccountinfo.mdx
@@ -6,3 +6,7 @@ description: "Returns all information associated with the account of provided Pu
 "og:description": "Get a free RPC and explore the getAccountInfo Method. Includes request parameters, response examples, code snippets, and in-browser testing for both Mainnet and Devnet."
 openapi: "/openapi/rpc-http/getAccountInfo.yaml POST /"
 ---
+
+<Info>
+**New Feature**: `getAccountInfo` now supports the `changedSinceSlot` parameter for incremental updates. When specified, the method returns only accounts that have been modified at or after the given slot number. For accounts that exist but haven't changed since the specified slot, the response will contain `status: "unchanged"`.
+</Info>

--- a/api-reference/rpc/http/getmultipleaccounts.mdx
+++ b/api-reference/rpc/http/getmultipleaccounts.mdx
@@ -6,3 +6,7 @@ description: "Returns the account information for a list of Pubkeys."
 "og:description": "Get a free RPC and explore the getMultipleAccounts RPC Method. Includes request parameters, response examples, code snippets, and in-browser testing for both Solana Mainnet and Devnet."
 openapi: "/openapi/rpc-http/getMultipleAccounts.yaml POST /"
 ---
+
+<Info>
+**New Feature**: `getMultipleAccounts` now supports the `changedSinceSlot` parameter for incremental updates. When specified, the method returns only accounts that have been modified at or after the given slot number. For accounts that exist but haven't changed since the specified slot, the response will contain `status: "unchanged"`.
+</Info>

--- a/api-reference/rpc/http/getprogramaccounts.mdx
+++ b/api-reference/rpc/http/getprogramaccounts.mdx
@@ -6,3 +6,7 @@ description: "Returns all accounts owned by the provided program Pubkey."
 "og:description": "Get a free RPC and explore the getProgramAccounts RPC Method. Includes request parameters, response examples, code snippets, and in-browser testing for both Solana Mainnet and Devnet."
 openapi: "/openapi/rpc-http/getProgramAccounts.yaml POST /"
 ---
+
+<Info>
+**New Feature**: `getProgramAccounts` now supports the `changedSinceSlot` parameter for incremental updates. When specified, the method returns only accounts that have been modified at or after the given slot number. This is perfect for real-time indexing and data synchronization workflows.
+</Info>

--- a/api-reference/rpc/http/gettokenaccountsbyowner.mdx
+++ b/api-reference/rpc/http/gettokenaccountsbyowner.mdx
@@ -6,3 +6,7 @@ description: "Returns all SPL Token accounts by token owner."
 "og:description": "Get a free RPC and explore the getTokenAccountsByOwner RPC Method. Includes request parameters, response examples, code snippets, and in-browser testing for both Solana Mainnet and Devnet."
 openapi: "/openapi/rpc-http/getTokenAccountsByOwner.yaml POST /"
 ---
+
+<Info>
+**New Feature**: `getTokenAccountsByOwner` now supports the `changedSinceSlot` parameter for incremental updates. When specified, the method returns only token accounts that have been modified at or after the given slot number. This is ideal for tracking token balance changes and portfolio updates.
+</Info>

--- a/openapi/rpc-http/getAccountInfo.yaml
+++ b/openapi/rpc-http/getAccountInfo.yaml
@@ -124,6 +124,10 @@ paths:
                             type: integer
                             description: The minimum slot that the request can be evaluated at.
                             example: 100000000
+                          changedSinceSlot:
+                            type: integer
+                            description: Only return the account if it has been modified at or after this slot number. If the account exists but hasn't changed since the specified slot, the response will contain status as "unchanged".
+                            example: 464175999
             example:
               jsonrpc: "2.0"
               id: 1
@@ -191,6 +195,15 @@ paths:
                                 type: integer
                                 description: The data size of the account.
                                 example: 0
+                          - type: object
+                            description: Status-only response when account exists but hasn't changed since the specified slot.
+                            properties:
+                              status:
+                                type: string
+                                description: Status indicating the account hasn't changed since the specified slot.
+                                enum:
+                                  - "unchanged"
+                                example: "unchanged"
                   id:
                     type: integer
                     description: A unique identifier matching the request ID.

--- a/openapi/rpc-http/getMultipleAccounts.yaml
+++ b/openapi/rpc-http/getMultipleAccounts.yaml
@@ -141,6 +141,10 @@ paths:
                               - base64
                               - base64+zstd
                             example: base58
+                          changedSinceSlot:
+                            type: integer
+                            description: Only return accounts that have been modified at or after this slot number. For accounts that exist but haven't changed since the specified slot, the response will contain status as "unchanged".
+                            example: 464175999
       responses:
         200:
           description: Successfully retrieved the account details.
@@ -213,6 +217,15 @@ paths:
                                   type: integer
                                   description: Data size of the account.
                                   example: 0
+                            - type: object
+                              description: Status-only response when account exists but hasn't changed since the specified slot.
+                              properties:
+                                status:
+                                  type: string
+                                  description: Status indicating the account hasn't changed since the specified slot.
+                                  enum:
+                                    - "unchanged"
+                                  example: "unchanged"
         400:
           description: Bad Request - Invalid request parameters or malformed request.
           content:

--- a/openapi/rpc-http/getProgramAccounts.yaml
+++ b/openapi/rpc-http/getProgramAccounts.yaml
@@ -141,6 +141,10 @@ paths:
                                 type: integer
                                 description: Byte offset from which to start reading.
                                 example: 0
+                          changedSinceSlot:
+                            type: integer
+                            description: Only return accounts that were modified at or after this slot number. Useful for incremental updates.
+                            example: 464175999
                           filters:
                             type: array
                             description: Powerful filtering system to efficiently query specific Solana account data patterns.

--- a/openapi/rpc-http/getTokenAccountsByOwner.yaml
+++ b/openapi/rpc-http/getTokenAccountsByOwner.yaml
@@ -140,6 +140,10 @@ paths:
                               - base64+zstd
                               - jsonParsed
                             example: jsonParsed
+                          changedSinceSlot:
+                            type: integer
+                            description: Only return accounts that were modified at or after this slot number. Useful for incremental updates.
+                            example: 464175999
             example:
               jsonrpc: "2.0"
               id: "1"

--- a/zh/api-reference/rpc/http/getaccountinfo.mdx
+++ b/zh/api-reference/rpc/http/getaccountinfo.mdx
@@ -7,3 +7,7 @@ og:description: 获取一个免费的 RPC 并探索 getAccountInfo 方法。包�
   Devnet 的浏览器内测试。
 openapi: /zh/openapi/rpc-http/getAccountInfo.yaml POST /
 ---
+
+<Info>
+**新功能**: `getAccountInfo` 现在支持 `changedSinceSlot` 参数用于增量更新。当指定此参数时，该方法只返回在给定槽号之后被修改的账户。对于存在但自指定槽以来没有变化的账户，响应将包含 `status: "unchanged"`。
+</Info>

--- a/zh/api-reference/rpc/http/getmultipleaccounts.mdx
+++ b/zh/api-reference/rpc/http/getmultipleaccounts.mdx
@@ -7,3 +7,7 @@ og:description: 获取免费 RPC 并探索 getMultipleAccounts RPC 方法。包�
   Solana 主网和 Devnet 的浏览器内测试。
 openapi: /zh/openapi/rpc-http/getMultipleAccounts.yaml POST /
 ---
+
+<Info>
+**新功能**: `getMultipleAccounts` 现在支持 `changedSinceSlot` 参数用于增量更新。当指定此参数时，该方法只返回在给定槽号之后被修改的账户。对于存在但自指定槽以来没有变化的账户，响应将包含 `status: "unchanged"`。
+</Info>

--- a/zh/api-reference/rpc/http/getprogramaccounts.mdx
+++ b/zh/api-reference/rpc/http/getprogramaccounts.mdx
@@ -7,3 +7,7 @@ og:description: 获取免费 RPC 并探索 getProgramAccounts RPC 方法。包�
   Solana 主网和 Devnet 上的浏览器内测试。
 openapi: /zh/openapi/rpc-http/getProgramAccounts.yaml POST /
 ---
+
+<Info>
+**新功能**: `getProgramAccounts` 现在支持 `changedSinceSlot` 参数用于增量更新。当指定此参数时，该方法只返回在给定槽号之后被修改的账户。这对于实时索引和数据同步工作流程非常理想。
+</Info>

--- a/zh/api-reference/rpc/http/gettokenaccountsbyowner.mdx
+++ b/zh/api-reference/rpc/http/gettokenaccountsbyowner.mdx
@@ -7,3 +7,7 @@ og:description: 获取免费 RPC 并探索 getTokenAccountsByOwner RPC 方法。
   Solana 主网和 Devnet 的浏览器内测试。
 openapi: /zh/openapi/rpc-http/getTokenAccountsByOwner.yaml POST /
 ---
+
+<Info>
+**新功能**: `getTokenAccountsByOwner` 现在支持 `changedSinceSlot` 参数用于增量更新。当指定此参数时，该方法只返回在给定槽号之后被修改的代币账户。这对于跟踪代币余额变化和投资组合更新非常理想。
+</Info>

--- a/zh/openapi/rpc-http/getAccountInfo.yaml
+++ b/zh/openapi/rpc-http/getAccountInfo.yaml
@@ -125,6 +125,10 @@ paths:
                             type: "integer"
                             description: "请求可以评估的最小槽位。"
                             example: 100000000
+                          changedSinceSlot:
+                            type: "integer"
+                            description: "仅返回在此槽号之后被修改的账户。如果账户存在但自指定槽以来没有变化，响应将包含状态为"unchanged"。"
+                            example: 464175999
             example:
               jsonrpc: "2.0"
               id: 1

--- a/zh/openapi/rpc-http/getMultipleAccounts.yaml
+++ b/zh/openapi/rpc-http/getMultipleAccounts.yaml
@@ -137,6 +137,10 @@ paths:
                               - "base64"
                               - "base64+zstd"
                             example: "base58"
+                          changedSinceSlot:
+                            type: "integer"
+                            description: "仅返回在此槽号之后被修改的账户。对于存在但自指定槽以来没有变化的账户，响应将包含状态为"unchanged"。"
+                            example: 464175999
       responses:
         "200":
           description: "成功检索到账户详细信息。"

--- a/zh/openapi/rpc-http/getProgramAccounts.yaml
+++ b/zh/openapi/rpc-http/getProgramAccounts.yaml
@@ -136,6 +136,10 @@ paths:
                                 type: "integer"
                                 description: "开始读取的字节偏移量。"
                                 example: 0
+                          changedSinceSlot:
+                            type: "integer"
+                            description: "仅返回在此槽号之后被修改的账户。用于增量更新。"
+                            example: 464175999
                           filters:
                             type: "array"
                             description: "强大的过滤系统，用于高效查询特定的Solana账户数据模式。"

--- a/zh/openapi/rpc-http/getTokenAccountsByOwner.yaml
+++ b/zh/openapi/rpc-http/getTokenAccountsByOwner.yaml
@@ -138,6 +138,10 @@ paths:
                               - "base64+zstd"
                               - "jsonParsed"
                             example: "jsonParsed"
+                          changedSinceSlot:
+                            type: "integer"
+                            description: "仅返回在此槽号之后被修改的账户。用于增量更新。"
+                            example: 464175999
             example:
               jsonrpc: "2.0"
               id: "1"


### PR DESCRIPTION
Add `changedSinceSlot` parameter to `getAccountInfo`, `getMultipleAccounts`, `getProgramAccounts`, and `getTokenAccountsByOwner` RPC methods and update their OpenAPI definitions and API reference pages.

This change enables incremental updates for these methods, allowing clients to efficiently query only accounts that have been modified at or after a specified slot. For `getAccountInfo` and `getMultipleAccounts`, it also introduces a `status: "unchanged"` response for existing accounts that have not changed since the provided slot, further optimizing data retrieval.

---
<a href="https://cursor.com/background-agent?bcId=bc-370ca906-7be7-427c-bcfc-6a4cc6f5f48e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-370ca906-7be7-427c-bcfc-6a4cc6f5f48e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

