### PR TITLE
Update i18n workflow to skip translation on specific merge commits

### DIFF
--- a/.github/workflows/i18n.yml
+++ b/.github/workflows/i18n.yml
@@ -19,6 +19,8 @@ concurrency:
 jobs:
   translate:
     runs-on: ubuntu-latest
+    # Skip if this is a translation merge commit
+    if: ${{ !contains(github.event.head_commit.message, '🌐 Auto-update Chinese translations') }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
- Added a condition to the translation job to skip execution if the commit message contains '🌐 Auto-update Chinese translations'. This change aims to prevent unnecessary translation runs for auto-generated updates.