### PR TITLE
Warning to use LS SDK

### DIFF
--- a/laserstream/clients.mdx
+++ b/laserstream/clients.mdx
@@ -10,11 +10,11 @@ LaserStream clients continuously track your streaming position by slot number. I
 
 ## JavaScript/TypeScript Client
 
-The [JavaScript client](https://github.com/helius-labs/laserstream-sdk/tree/main/javascript) uses native Rust bindings to achieve 1.3GB/s throughput – over 40x faster than Yellowstone gRPC JavaScript clients that max out at 30MB/s.
-
 <Warning>
-As Solana continues to scale, Yellowstone JavaScript client will struggle to keep up. If Solana speeds up 3x, Yellowstone gRPC clients subscribing to all transactions or blocks will fail to match chain speed. LaserSstream client's performance headroom ensures your application scales with the network.
+**We highly recommend switching to LaserStream SDK for JavaScript apps.** If you're currently using Yellowstone gRPC clients, you will experience progressive stream delays and performance bottlenecks that compound over time. LaserStream client's performance headroom ensures your app scales with the network and eliminates these issues entirely.
 </Warning>
+
+The [JavaScript client](https://github.com/helius-labs/laserstream-sdk/tree/main/javascript) uses native Rust bindings to achieve 1.3GB/s throughput – over 40x faster than Yellowstone gRPC JavaScript clients that max out at 30MB/s.
 
 On high-bandwidth subscriptions, Yellowstone clients experience progressive delays that compound over time. LaserStream maintains consistent, low-latency streaming regardless of data volume.
 


### PR DESCRIPTION
Add explicit warning recommending LaserStream SDK over Yellowstone for JavaScript apps to avoid stream delays