### PR TITLE
Update Sender API rate limits from 6 TPS to 15 TPS across documentati…

### DIFF
--- a/billing/plans-and-rate-limits.mdx
+++ b/billing/plans-and-rate-limits.mdx
@@ -241,10 +241,10 @@ Some endpoints have special restrictions due to their computational requirements
       <tbody>
         <tr>
           <td><code>Sender</code></td>
-          <td>6/sec</td>
-          <td>6/sec</td>
-          <td>6/sec</td>
-          <td>6/sec</td>
+          <td>15/sec</td>
+          <td>15/sec</td>
+          <td>15/sec</td>
+          <td>15/sec</td>
         </tr>
         <tr>
           <td><code>sendTransaction</code></td>

--- a/faqs/sender.mdx
+++ b/faqs/sender.mdx
@@ -11,8 +11,8 @@ Sender is a specialized service for ultra-low latency transaction submission. It
 With seven regional endpoints, typical land-time is ≤ 1.5 slots.
 </Accordion>
 
-<Accordion title="Can I get a higher Sender API limit than 6 transactions per second (TPS)?">
-Yes! While the standard limit is 6 TPS per region, you can request higher limits. Professional plan users can access significant rate limit upgrades to support high-throughput trading applications. [Fill out this form](https://form.typeform.com/to/FuvpgSNt) to request custom rate limits based on your specific use case requirements.
+<Accordion title="Can I get a higher Sender API limit than 15 transactions per second (TPS)?">
+Yes! While the standard limit is 15 TPS per region, you can request higher limits. Professional plan users can access significant rate limit upgrades to support high-throughput trading applications. [Fill out this form](https://form.typeform.com/to/FuvpgSNt) to request custom rate limits based on your specific use case requirements.
 </Accordion>
 
 <Accordion title="How do I set tips and priority fees with Sender?">

--- a/sending-transactions/sender.mdx
+++ b/sending-transactions/sender.mdx
@@ -20,7 +20,7 @@ Helius Sender is a specialized service for ultra-low latency transaction submiss
     Available on all plans without consuming API credits
   </Card>
   <Card title="High Throughput" icon="gauge-high" href="https://form.typeform.com/to/FuvpgSNt">
-    Default 6 TPS, request higher limits for your needs
+    Default 15 TPS, request higher limits for your needs
   </Card>
 </CardGroup>
 
@@ -1271,7 +1271,7 @@ export { sendWithSender };
 
 ## Rate Limits and Scaling
 
-- **Default Rate Limit**: 6 transactions per second
+- **Default Rate Limit**: 15 transactions per second
 - **No Credit Usage**: Sender transactions don't consume API credits from your plan
 - **Professional Plan Upgrades**: Professional plan users can request significant rate limit increases to support high-throughput trading applications
 
@@ -1280,7 +1280,7 @@ export { sendWithSender };
 For production deployments requiring higher throughput:
 
 <Card title="Request Higher TPS Limits" icon="rocket" href="https://form.typeform.com/to/FuvpgSNt">
-Need more than 6 TPS? Fill out our request form. Professional plan users can access significant rate limit upgrades for high-frequency trading applications.
+Need more than 15 TPS? Fill out our request form. Professional plan users can access significant rate limit upgrades for high-frequency trading applications.
 </Card>
 
 Additional support options:


### PR DESCRIPTION
…on, reflecting new default limits and request procedures for higher throughput.