### PR TITLE
Update getTransactionsForAddress documentation to specify credit cost…

### DIFF
--- a/rpc/gettransactionsforaddress.mdx
+++ b/rpc/gettransactionsforaddress.mdx
@@ -6,7 +6,7 @@ description: "Learn how to query Solana transaction history with advanced filter
 
 
 <Tip>
-**Helius Exclusive Feature** - `getTransactionsForAddress` is only available through Helius RPC nodes and is not part of standard Solana RPC. This endpoint requires a [Developer plan](/billing/plans-and-rate-limits) or higher.
+**Helius Exclusive Feature** - `getTransactionsForAddress` is only available through Helius RPC nodes and is not part of standard Solana RPC. This endpoint requires a [Developer plan](/billing/plans-and-rate-limits) or higher and costs 100 credits per request.
 </Tip>
 
 ## Overview


### PR DESCRIPTION
…s per request

- Clarified that the endpoint requires 100 credits per request, enhancing transparency for users regarding usage costs.
- Maintained emphasis on the exclusivity of the feature through Helius RPC nodes and Developer plan requirements.