### PR TITLE
Fix API spec of simulateBundle

### DIFF
--- a/openapi/rpc-http/simulateBundle.yaml
+++ b/openapi/rpc-http/simulateBundle.yaml
@@ -307,7 +307,7 @@ paths:
                             description: |
                               Summary of the bundle simulation result.
 
-                              If the simulation was successful, this is set to `"succeeded"`.
+                              If the simulation succeeded, this is set to `"succeeded"`.
 
                               If the simulation failed, this is set to an object with a single field `failed` that contains details on that failure.
                             oneOf:


### PR DESCRIPTION
In the Response part, describe the output format in the case the simulation failed.