### PR TITLE
Enh WSS: fix maxSupportedTransactionVersion

### DIFF
--- a/enhanced-websockets/transaction-subscribe.mdx
+++ b/enhanced-websockets/transaction-subscribe.mdx
@@ -36,7 +36,7 @@ You can include up to 50,000 addresses in the accountsInclude, accountExclude an
 
 `showRewards`: A boolean flag indicating if reward data should be included in the transaction updates.
 
-`maxSupportedTransactionVersion`: Specifies the highest version of transactions you want to receive updates. To get Versioned Transactions, set the value to `0`.
+`maxSupportedTransactionVersion`: Specifies the highest version of transactions you want to receive updates from. To get both legacy and v0 transactions, set the value to `0`.
 
 <Info>
 `maxSupportedTransactionVersion` is required to return the accounts and full-level details of a given transaction (i.e., `transactionDetails: "accounts" | "full"`).


### PR DESCRIPTION
To get versioned tx, we set the field to `0` not `1`