### PR TITLE
docs: clarify distinction between Shred Delivery and LaserStream

### DIFF
--- a/laserstream.mdx
+++ b/laserstream.mdx
@@ -43,8 +43,6 @@ Unlike standard Solana RPC nodes, LaserStream is specifically designed for strea
 | **Best For** | Production applications, analytics, backend services | High-frequency trading, arbitrage (when milliseconds matter) |
 | **Setup** | Developer-friendly SDKs, drop-in replacement | White glove provisioning (beta access required) |
 
-**Key Distinction**: LaserStream provides processed, structured data with reliability features like historical replay and automatic reconnection—ideal for production applications. Shred Delivery provides the **absolute earliest signal** from Solana's network, but requires you to handle raw data processing.
-
 <Card title="Learn About Shred Delivery" icon="bolt" href="/shred-delivery">
   See how Shred Delivery provides the earliest possible on-chain signal with raw shreds
 </Card>

--- a/shred-delivery.mdx
+++ b/shred-delivery.mdx
@@ -45,8 +45,6 @@ Shred Delivery is Helius's **specialized delivery of raw Solana shreds via UDP**
 | **Best For** | High-frequency trading, arbitrage (when milliseconds matter) | Production applications, analytics, backend services |
 | **Setup** | White glove provisioning (beta access required) | Developer-friendly SDKs, drop-in replacement |
 
-**Key Distinction**: Shred Delivery gives you the **absolute earliest signal** from Solana's network, but requires you to handle raw data processing. LaserStream delivers processed, structured data with reliability features—ideal when you need production-ready streaming without custom processing infrastructure.
-
 <Card title="Learn About LaserStream" icon="rocket" href="/laserstream">
   See how LaserStream delivers processed data with commitment guarantees and reliability features
 </Card>


### PR DESCRIPTION
Add prominent TLDR comparison sections to both Shred Delivery and LaserStream landing pages to help users understand the key differences:

- Shred Delivery: earliest possible on-chain signal with raw shreds, but requires custom deshredding logic
- LaserStream: processed data with commitment guarantees, turnkey solution with developer-friendly SDKs

The comparison tables and TLDR sections are placed near the top of each page to match customer flow, addressing common questions about when to use each service.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds prominent TL;DR tips, comparison tables, and cross-link cards to `laserstream.mdx` and `shred-delivery.mdx` to clarify processed vs. raw data offerings.
> 
> - **Docs**:
>   - **`laserstream.mdx`**:
>     - Add TL;DR tip and quick comparison table vs. Shred Delivery.
>     - Add cross-link card to `/shred-delivery`.
>   - **`shred-delivery.mdx`**:
>     - Add TL;DR tip and quick comparison table vs. LaserStream.
>     - Add cross-link card to `/laserstream`.
>     - Refine detailed comparison section: updated heading, bullets, and "When to choose each" guidance.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2b7c5ce1d6877b1f0f492059c3a5d4f021792f41. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->