### PR TITLE
Remove sendJitoBundle reference from DN docs

### DIFF
--- a/dedicated-nodes/getting-started.mdx
+++ b/dedicated-nodes/getting-started.mdx
@@ -51,8 +51,6 @@ You can customize your node by selecting the client type — either Agave or Jit
 
 <Note>
 Dedicated nodes **cannot** send Jito Bundles on their own. To send Jito Bundles, you must use the Jito API, which handles packaging and sending the bundles through Jito's system.
-
-To simplify this process, our SDK provides an easy method called [Send Jito Bundle](https://github.com/helius-labs/helius-sdk/tree/main?tab=readme-ov-file#sendJitoBundle).
 </Note>
 
 ### Geyser Plugin (Recommended)


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Removes the SDK "Send Jito Bundle" reference from the Dedicated Nodes getting-started note, retaining guidance to use the Jito API.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 56c0534eb05c3f3065d6a5becbb366cb02849698. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->