### PR TITLE
feat(val-api): Add Validator API to Docs

### DIFF
--- a/validator-reporting/apy.mdx
+++ b/validator-reporting/apy.mdx
@@ -10,7 +10,7 @@ description: "Calculate validator Annual Percentage Yield with both gross APY (t
 ## Endpoint
 
 ```
-GET http://validator-api.helius-internal.com/validators/{vote_account}/apy
+GET https://mainnet.helius-rpc.com/validators/{vote_account}/apy
 ```
 
 ## Description
@@ -45,6 +45,10 @@ where num_epochs_per_year ≈ 182.5
 
 ## Query Parameters
 
+<ParamField query="api-key" type="string" required>
+  Your Helius API key for authentication
+</ParamField>
+
 <ParamField query="period" type="string" default="30d">
   Time period for APY calculation
 
@@ -75,22 +79,23 @@ where num_epochs_per_year ≈ 182.5
 <CodeGroup>
 
 ```bash cURL - Basic APY
-curl -s "http://validator-api.helius-internal.com/validators/he1iusunGwqrNtafDtLdhsUQDFvo13z9sUa36PauBtk/apy?period=30d"
+curl -s "https://mainnet.helius-rpc.com/validators/he1iusunGwqrNtafDtLdhsUQDFvo13z9sUa36PauBtk/apy?api-key=YOUR_API_KEY&period=30d"
 ```
 
 ```bash cURL - With Forecast
-curl -s "http://validator-api.helius-internal.com/validators/he1iusunGwqrNtafDtLdhsUQDFvo13z9sUa36PauBtk/apy?period=30d&include_forecast=true"
+curl -s "https://mainnet.helius-rpc.com/validators/he1iusunGwqrNtafDtLdhsUQDFvo13z9sUa36PauBtk/apy?api-key=YOUR_API_KEY&period=30d&include_forecast=true"
 ```
 
 ```bash cURL - Single Epoch
-curl -s "http://validator-api.helius-internal.com/validators/he1iusunGwqrNtafDtLdhsUQDFvo13z9sUa36PauBtk/apy?period=epoch&start_epoch=800"
+curl -s "https://mainnet.helius-rpc.com/validators/he1iusunGwqrNtafDtLdhsUQDFvo13z9sUa36PauBtk/apy?api-key=YOUR_API_KEY&period=epoch&start_epoch=800"
 ```
 
 ```javascript JavaScript
-const getValidatorAPY = async (voteAccount, period = '30d', includeForecast = false) => {
-  const baseUrl = 'http://validator-api.helius-internal.com';
+const getValidatorAPY = async (voteAccount, apiKey, period = '30d', includeForecast = false) => {
+  const baseUrl = 'https://mainnet.helius-rpc.com';
 
   const params = new URLSearchParams({
+    'api-key': apiKey,
     period,
     ...(includeForecast && { include_forecast: 'true' })
   });
@@ -105,6 +110,7 @@ const getValidatorAPY = async (voteAccount, period = '30d', includeForecast = fa
 // Usage
 const apy = await getValidatorAPY(
   'he1iusunGwqrNtafDtLdhsUQDFvo13z9sUa36PauBtk',
+  'YOUR_API_KEY',
   '30d',
   true
 );
@@ -120,13 +126,15 @@ import requests
 
 def get_validator_apy(
     vote_account: str,
+    api_key: str,
     period: str = "30d",
     include_forecast: bool = False
 ):
-    base_url = "http://validator-api.helius-internal.com"
-    
+    base_url = "https://mainnet.helius-rpc.com"
+
 
     params = {
+        "api-key": api_key,
         "period": period,
     }
 
@@ -140,6 +148,7 @@ def get_validator_apy(
 # Usage
 apy = get_validator_apy(
     "he1iusunGwqrNtafDtLdhsUQDFvo13z9sUa36PauBtk",
+    "YOUR_API_KEY",
     "30d",
     include_forecast=True
 )

--- a/validator-reporting/earnings.mdx
+++ b/validator-reporting/earnings.mdx
@@ -10,7 +10,7 @@ description: "Comprehensive earnings data including voting, block production, re
 ## Endpoint
 
 ```
-GET http://validator-api.helius-internal.com/validators/{vote_account}/earnings
+GET https://mainnet.helius-rpc.com/validators/{vote_account}/earnings
 ```
 
 ## Description
@@ -34,6 +34,10 @@ This endpoint provides a complete financial picture of validator operations over
 ---
 
 ## Query Parameters
+
+<ParamField query="api-key" type="string" required>
+  Your Helius API key for authentication
+</ParamField>
 
 <ParamField query="period" type="string" default="30d">
   Time period for earnings aggregation
@@ -61,17 +65,17 @@ This endpoint provides a complete financial picture of validator operations over
 <CodeGroup>
 
 ```bash cURL - 30 Day Period
-curl -s "http://validator-api.helius-internal.com/validators/he1iusunGwqrNtafDtLdhsUQDFvo13z9sUa36PauBtk/earnings?period=30d" | python3 -m json.tool
+curl -s "https://mainnet.helius-rpc.com/validators/he1iusunGwqrNtafDtLdhsUQDFvo13z9sUa36PauBtk/earnings?period=30d&api-key=YOUR_API_KEY" | python3 -m json.tool
 ```
 
 ```bash cURL - Custom Epoch Range
-curl -s "http://validator-api.helius-internal.com/validators/he1iusunGwqrNtafDtLdhsUQDFvo13z9sUa36PauBtk/earnings?start_epoch=800&end_epoch=850" | python3 -m json.tool
+curl -s "https://mainnet.helius-rpc.com/validators/he1iusunGwqrNtafDtLdhsUQDFvo13z9sUa36PauBtk/earnings?start_epoch=800&end_epoch=850&api-key=YOUR_API_KEY" | python3 -m json.tool
 ```
 
 ```javascript JavaScript
-const getValidatorEarnings = async (voteAccount, period = '30d') => {
-  const baseUrl = 'http://validator-api.helius-internal.com';
-  const url = `${baseUrl}/validators/${voteAccount}/earnings?period=${period}`;
+const getValidatorEarnings = async (voteAccount, apiKey, period = '30d') => {
+  const baseUrl = 'https://mainnet.helius-rpc.com';
+  const url = `${baseUrl}/validators/${voteAccount}/earnings?period=${period}&api-key=${apiKey}`;
 
   const response = await fetch(url);
   const data = await response.json();
@@ -82,6 +86,7 @@ const getValidatorEarnings = async (voteAccount, period = '30d') => {
 // Usage
 const earnings = await getValidatorEarnings(
   'he1iusunGwqrNtafDtLdhsUQDFvo13z9sUa36PauBtk',
+  'YOUR_API_KEY',
   '30d'
 );
 
@@ -93,10 +98,13 @@ console.log('Skip rate:', earnings.earnings.block_production.skip_rate_pct, '%')
 ```python Python
 import requests
 
-def get_validator_earnings(vote_account: str, period: str = "30d"):
-    base_url = "http://validator-api.helius-internal.com"
+def get_validator_earnings(vote_account: str, api_key: str, period: str = "30d"):
+    base_url = "https://mainnet.helius-rpc.com"
     url = f"{base_url}/validators/{vote_account}/earnings"
-    params = {"period": period}
+    params = {
+        "period": period,
+        "api-key": api_key
+    }
 
     response = requests.get(url, params=params)
     return response.json()
@@ -104,6 +112,7 @@ def get_validator_earnings(vote_account: str, period: str = "30d"):
 # Usage
 earnings = get_validator_earnings(
     "he1iusunGwqrNtafDtLdhsUQDFvo13z9sUa36PauBtk",
+    "YOUR_API_KEY",
     "30d"
 )
 

--- a/validator-reporting/index.mdx
+++ b/validator-reporting/index.mdx
@@ -17,8 +17,12 @@ This is a private API available only to select partners.
 ### Base URL
 
 ```
-http://validator-api.helius-internal.com
+https://mainnet.helius-rpc.com/validators
 ```
+
+### Authentication
+
+All API requests require an `api-key` query parameter for validation.
 
 ### Key Concepts
 
@@ -58,14 +62,15 @@ Example: `he1iusunGwqrNtafDtLdhsUQDFvo13z9sUa36PauBtk`
     Get 30-day earnings for a validator:
 
     ```bash
-    curl -s "http://validator-api.helius-internal.com/validators/he1iusunGwqrNtafDtLdhsUQDFvo13z9sUa36PauBtk/earnings?period=30d" | python3 -m json.tool
+    curl -s "https://mainnet.helius-rpc.com/validators/he1iusunGwqrNtafDtLdhsUQDFvo13z9sUa36PauBtk/earnings?period=30d&api-key=YOUR_API_KEY" | python3 -m json.tool
     ```
 
     JavaScript:
     ```javascript
     const voteAccount = 'he1iusunGwqrNtafDtLdhsUQDFvo13z9sUa36PauBtk';
+    const apiKey = 'YOUR_API_KEY';
     const response = await fetch(
-      `http://validator-api.helius-internal.com/validators/${voteAccount}/earnings?period=30d`
+      `https://mainnet.helius-rpc.com/validators/${voteAccount}/earnings?period=30d&api-key=${apiKey}`
     );
     const data = await response.json();
     console.log(`Gross earnings: ${data.earnings.rewards.gross_earnings_sol} SOL`);
@@ -76,7 +81,7 @@ Example: `he1iusunGwqrNtafDtLdhsUQDFvo13z9sUa36PauBtk`
     Get 7-day APY for a validator:
 
     ```bash
-    curl -s "http://validator-api.helius-internal.com/validators/he1iusunGwqrNtafDtLdhsUQDFvo13z9sUa36PauBtk/apy?period=7d" | python3 -m json.tool
+    curl -s "https://mainnet.helius-rpc.com/validators/he1iusunGwqrNtafDtLdhsUQDFvo13z9sUa36PauBtk/apy?period=7d&api-key=YOUR_API_KEY" | python3 -m json.tool
     ```
   </Tab>
 
@@ -84,7 +89,7 @@ Example: `he1iusunGwqrNtafDtLdhsUQDFvo13z9sUa36PauBtk`
     Get 7-day performance metrics:
 
     ```bash
-    curl -s "http://validator-api.helius-internal.com/validators/he1iusunGwqrNtafDtLdhsUQDFvo13z9sUa36PauBtk/performance?period=7d" | python3 -m json.tool
+    curl -s "https://mainnet.helius-rpc.com/validators/he1iusunGwqrNtafDtLdhsUQDFvo13z9sUa36PauBtk/performance?period=7d&api-key=YOUR_API_KEY" | python3 -m json.tool
     ```
   </Tab>
 
@@ -92,7 +97,7 @@ Example: `he1iusunGwqrNtafDtLdhsUQDFvo13z9sUa36PauBtk`
     Get 30-day rewards forecast:
 
     ```bash
-    curl -s "http://validator-api.helius-internal.com/validators/he1iusunGwqrNtafDtLdhsUQDFvo13z9sUa36PauBtk/rewards/forecast?forecast_period=30d&lookback_days=30" | python3 -m json.tool
+    curl -s "https://mainnet.helius-rpc.com/validators/he1iusunGwqrNtafDtLdhsUQDFvo13z9sUa36PauBtk/rewards/forecast?forecast_period=30d&lookback_days=30&api-key=YOUR_API_KEY" | python3 -m json.tool
     ```
   </Tab>
 
@@ -114,6 +119,10 @@ Example: `he1iusunGwqrNtafDtLdhsUQDFvo13z9sUa36PauBtk`
 ## Common Parameters
 
 Many endpoints share these common query parameters:
+
+<ParamField query="api-key" type="string" required>
+  Your Helius API key for authentication
+</ParamField>
 
 <ParamField query="period" type="string">
   Time period for data aggregation

--- a/validator-reporting/performance.mdx
+++ b/validator-reporting/performance.mdx
@@ -10,7 +10,7 @@ description: "Operational metrics including vote participation, skip rates, and 
 ## Endpoint
 
 ```
-GET http://validator-api.helius-internal.com/validators/{vote_account}/performance
+GET https://mainnet.helius-rpc.com/validators/{vote_account}/performance
 ```
 
 ## Description
@@ -47,6 +47,10 @@ Retrieve comprehensive operational performance metrics for a validator, includin
 
 ## Query Parameters
 
+<ParamField query="api-key" type="string" required>
+  Your Helius API key for authentication
+</ParamField>
+
 <ParamField query="period" type="string" default="30d">
   Time period for performance metrics
 
@@ -73,18 +77,23 @@ Retrieve comprehensive operational performance metrics for a validator, includin
 <CodeGroup>
 
 ```bash cURL - 30 Day Performance
-curl -s "http://validator-api.helius-internal.com/validators/he1iusunGwqrNtafDtLdhsUQDFvo13z9sUa36PauBtk/performance?period=30d"
+curl -s "https://mainnet.helius-rpc.com/validators/he1iusunGwqrNtafDtLdhsUQDFvo13z9sUa36PauBtk/performance?api-key=YOUR_API_KEY&period=30d"
 ```
 
 ```bash cURL - Custom Epoch Range
-curl -s "http://validator-api.helius-internal.com/validators/he1iusunGwqrNtafDtLdhsUQDFvo13z9sUa36PauBtk/performance?start_epoch=800&end_epoch=850"
+curl -s "https://mainnet.helius-rpc.com/validators/he1iusunGwqrNtafDtLdhsUQDFvo13z9sUa36PauBtk/performance?api-key=YOUR_API_KEY&start_epoch=800&end_epoch=850"
 ```
 
 ```javascript JavaScript
-const getValidatorPerformance = async (voteAccount, period = '30d') => {
-  const baseUrl = 'http://validator-api.helius-internal.com';
+const getValidatorPerformance = async (voteAccount, apiKey, period = '30d') => {
+  const baseUrl = 'https://mainnet.helius-rpc.com';
 
-  const url = `${baseUrl}/validators/${voteAccount}/performance?period=${period}`;
+  const params = new URLSearchParams({
+    'api-key': apiKey,
+    period
+  });
+
+  const url = `${baseUrl}/validators/${voteAccount}/performance?${params}`;
 
   const response = await fetch(url);
   const data = await response.json();
@@ -95,6 +104,7 @@ const getValidatorPerformance = async (voteAccount, period = '30d') => {
 // Usage
 const performance = await getValidatorPerformance(
   'he1iusunGwqrNtafDtLdhsUQDFvo13z9sUa36PauBtk',
+  'YOUR_API_KEY',
   '30d'
 );
 
@@ -115,12 +125,13 @@ if (performance.participation.missing_epochs > 0) {
 ```python Python
 import requests
 
-def get_validator_performance(vote_account: str, period: str = "30d"):
-    base_url = "http://validator-api.helius-internal.com"
-    
+def get_validator_performance(vote_account: str, api_key: str, period: str = "30d"):
+    base_url = "https://mainnet.helius-rpc.com"
+
 
     url = f"{base_url}/validators/{vote_account}/performance"
     params = {
+        "api-key": api_key,
         "period": period,
     }
 
@@ -130,6 +141,7 @@ def get_validator_performance(vote_account: str, period: str = "30d"):
 # Usage
 performance = get_validator_performance(
     "he1iusunGwqrNtafDtLdhsUQDFvo13z9sUa36PauBtk",
+    "YOUR_API_KEY",
     "30d"
 )
 

--- a/validator-reporting/rewards-forecast.mdx
+++ b/validator-reporting/rewards-forecast.mdx
@@ -10,7 +10,7 @@ description: "Rewards forecasting with multiple models, confidence intervals, an
 ## Endpoint
 
 ```
-GET http://validator-api.helius-internal.com/validators/{vote_account}/rewards/forecast
+GET https://mainnet.helius-rpc.com/validators/{vote_account}/rewards/forecast
 ```
 
 ## Description
@@ -52,6 +52,10 @@ Where num_epochs_per_year ≈ 182.5
 
 ## Query Parameters
 
+<ParamField query="api-key" type="string" required>
+  Your Helius API key for authentication
+</ParamField>
+
 <ParamField query="forecast_period" type="string" default="30d">
   Time period to forecast into the future
 
@@ -86,18 +90,19 @@ Where num_epochs_per_year ≈ 182.5
 <CodeGroup>
 
 ```bash cURL - Basic Forecast
-curl -s "http://validator-api.helius-internal.com/validators/he1iusunGwqrNtafDtLdhsUQDFvo13z9sUa36PauBtk/rewards/forecast?forecast_period=30d"
+curl -s "https://mainnet.helius-rpc.com/validators/he1iusunGwqrNtafDtLdhsUQDFvo13z9sUa36PauBtk/rewards/forecast?api-key=YOUR_API_KEY&forecast_period=30d"
 ```
 
 ```bash cURL - Linear Regression with Breakdown
-curl -s "http://validator-api.helius-internal.com/validators/he1iusunGwqrNtafDtLdhsUQDFvo13z9sUa36PauBtk/rewards/forecast?forecast_period=90d&lookback_days=60&model=linear_regression&include_breakdown=true"
+curl -s "https://mainnet.helius-rpc.com/validators/he1iusunGwqrNtafDtLdhsUQDFvo13z9sUa36PauBtk/rewards/forecast?api-key=YOUR_API_KEY&forecast_period=90d&lookback_days=60&model=linear_regression&include_breakdown=true"
 ```
 
 ```javascript JavaScript
-const getRewardsForecast = async (voteAccount, options = {}) => {
-  const baseUrl = 'http://validator-api.helius-internal.com';
+const getRewardsForecast = async (voteAccount, apiKey, options = {}) => {
+  const baseUrl = 'https://mainnet.helius-rpc.com';
 
   const params = new URLSearchParams({
+    'api-key': apiKey,
     forecast_period: options.forecastPeriod || '30d',
     lookback_days: options.lookbackDays || 30,
     model: options.model || 'rolling_average',
@@ -114,6 +119,7 @@ const getRewardsForecast = async (voteAccount, options = {}) => {
 // Usage - Rolling Average
 const forecast = await getRewardsForecast(
   'he1iusunGwqrNtafDtLdhsUQDFvo13z9sUa36PauBtk',
+  'YOUR_API_KEY',
   {
     forecastPeriod: '30d',
     lookbackDays: 30,
@@ -129,6 +135,7 @@ console.log('Confidence:', forecast.methodology.confidence);
 // Usage - Linear Regression
 const trendForecast = await getRewardsForecast(
   'he1iusunGwqrNtafDtLdhsUQDFvo13z9sUa36PauBtk',
+  'YOUR_API_KEY',
   {
     forecastPeriod: '90d',
     lookbackDays: 60,
@@ -145,15 +152,17 @@ import requests
 
 def get_rewards_forecast(
     vote_account: str,
+    api_key: str,
     forecast_period: str = "30d",
     lookback_days: int = 30,
     model: str = "rolling_average",
     include_breakdown: bool = False
 ):
-    base_url = "http://validator-api.helius-internal.com"
-    
+    base_url = "https://mainnet.helius-rpc.com"
+
 
     params = {
+        "api-key": api_key,
         "forecast_period": forecast_period,
         "lookback_days": lookback_days,
         "model": model,
@@ -167,6 +176,7 @@ def get_rewards_forecast(
 # Usage - Rolling Average
 forecast = get_rewards_forecast(
     "he1iusunGwqrNtafDtLdhsUQDFvo13z9sUa36PauBtk",
+    "YOUR_API_KEY",
     forecast_period="30d",
     lookback_days=30,
     model="rolling_average",
@@ -180,6 +190,7 @@ print(f"Confidence: {forecast['methodology']['confidence']}")
 # Usage - Linear Regression
 trend_forecast = get_rewards_forecast(
     "he1iusunGwqrNtafDtLdhsUQDFvo13z9sUa36PauBtk",
+    "YOUR_API_KEY",
     forecast_period="90d",
     lookback_days=60,
     model="linear_regression"


### PR DESCRIPTION
This PR aims to add new documentation for the validator API. This is unlinked from the rest of the docs as it is intended only for select partners (currently Bitwise)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds private Validator Reporting API docs covering APY, earnings, performance, and rewards forecasting with endpoints, schemas, examples, and errors.
> 
> - **Docs: Validator Reporting API (private)**
>   - New overview and quick start in `validator-reporting/index.mdx` with common params and endpoint links.
>   - New endpoint docs:
>     - `validators/{vote_account}/earnings` (`validator-reporting/earnings.mdx`): voting/block-production metrics, rewards breakdown, commission rates/splits, response schema, errors, examples.
>     - `validators/{vote_account}/apy` (`validator-reporting/apy.mdx`): gross vs staker APY, breakdown (inflation/MEV/block), partial-epoch handling, optional forecast, schema, examples, errors.
>     - `validators/{vote_account}/performance` (`validator-reporting/performance.mdx`): vote participation, skip rate, epoch gaps, benchmarks, schema, examples, errors.
>     - `validators/{vote_account}/rewards/forecast` (`validator-reporting/rewards-forecast.mdx`): rolling-average/linear-regression models, conservative/baseline/optimistic projections, methodology/confidence, schema, examples, errors.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 39cf613d8e6201439a72ed4922b37cd36cc63607. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->