### PR TITLE
add docs for new transactionIndex field

### DIFF
--- a/openapi/rpc-http/getTransactionsForAddress.yaml
+++ b/openapi/rpc-http/getTransactionsForAddress.yaml
@@ -312,6 +312,10 @@ paths:
                                   type: integer
                                   description: The slot that contains the block with the transaction.
                                   example: 1054
+                                transactionIndex:
+                                  type: integer
+                                  description: The zero-based index of the transaction within its block. Useful for determining transaction ordering within a block.
+                                  example: 42
                                 err:
                                   oneOf:
                                     - type: object
@@ -355,6 +359,10 @@ paths:
                                   type: integer
                                   description: The slot that contains the block with the transaction.
                                   example: 1054
+                                transactionIndex:
+                                  type: integer
+                                  description: The zero-based index of the transaction within its block. Useful for determining transaction ordering within a block.
+                                  example: 42
                                 transaction:
                                   type: object
                                   description: Encoded or parsed transaction object per the selected encoding.
@@ -387,12 +395,14 @@ paths:
                       data:
                         - signature: "5h6xBEauJ3PK6SWCZ1PGjBvj8vDdWG3KpwATGy1ARAXFSDwt8GFXM7W5Ncn16wmqokgpiKRLuS83KUxyZyv2sUYv"
                           slot: 1054
+                          transactionIndex: 42
                           err: null
                           memo: null
                           blockTime: 1641038400
                           confirmationStatus: "finalized"
                         - signature: "kwjd820slPK6SWCZ1PGjBvj8vDdWG3KpwATGy1ARAXFSDwt8GFXM7W5Ncn16wmqokgpiKRLuS83KUxyZyv2sUYv"
                           slot: 1055
+                          transactionIndex: 15
                           err: null
                           memo: null
                           blockTime: 1641038460
@@ -406,6 +416,7 @@ paths:
                     result:
                       data:
                         - slot: 1054
+                          transactionIndex: 42
                           transaction:
                             signatures:
                               - "5h6xBEauJ3PK6SWCZ1PGjBvj8vDdWG3KpwATGy1ARAXFSDwt8GFXM7W5Ncn16wmqokgpiKRLuS83KUxyZyv2sUYv"

--- a/rpc/gettransactionsforaddress.mdx
+++ b/rpc/gettransactionsforaddress.mdx
@@ -239,6 +239,7 @@ When using filters, you can use comparison operators for `slot`, `blockTime`, or
           {
             "signature": "5h6xBEauJ3PK6SWCZ1PGjBvj8vDdWG3KpwATGy1ARAXFSDwt8GFXM7W5Ncn16wmqokgpiKRLuS83KUxyZyv2sUYv",
             "slot": 1054,
+            "transactionIndex": 42,
             "err": null,
             "memo": null,
             "blockTime": 1641038400,
@@ -254,12 +255,14 @@ When using filters, you can use comparison operators for `slot`, `blockTime`, or
   <Tab title="Full Transaction Response">
     ```json
     {
-      "jsonrpc": "2.0", 
+      "jsonrpc": "2.0",
       "id": 1,
       "result": {
         "data": [
           {
             "slot": 1054,
+            "transactionIndex": 42,
+            "blockTime": 1641038400,
             "transaction": {
               "signatures": ["5h6xBEauJ3PK6SWCZ1PGjBvj8vDdWG3KpwATGy1ARAXFSDwt8GFXM7W5Ncn16wmqokgpiKRLuS83KUxyZyv2sUYv"],
               "message": {
@@ -282,6 +285,25 @@ When using filters, you can use comparison operators for `slot`, `blockTime`, or
     ```
   </Tab>
 </Tabs>
+
+### Response Fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `signature` | string | Transaction signature (base-58 encoded). Only in signatures mode. |
+| `slot` | number | The slot containing the block with this transaction. |
+| `transactionIndex` | number | The zero-based index of the transaction within its block. Useful for transaction ordering and block reconstruction. |
+| `blockTime` | number \| null | Estimated production time as Unix timestamp (seconds since epoch). |
+| `err` | object \| null | Error if the transaction failed, null if successful. Only in signatures mode. |
+| `memo` | string \| null | Memo associated with the transaction. Only in signatures mode. |
+| `confirmationStatus` | string | Transaction's cluster confirmation status. Only in signatures mode. |
+| `transaction` | object | Full transaction data. Only in full mode. |
+| `meta` | object | Transaction status metadata. Only in full mode. |
+| `paginationToken` | string \| null | Token for fetching the next page, or null if no more results. |
+
+<Note>
+The `transactionIndex` field is exclusive to `getTransactionsForAddress`. Other similar endpoints like `getSignaturesForAddress`, `getTransaction`, and `getTransactions` do not include this field.
+</Note>
 
 ---
 

--- a/zh/openapi/rpc-http/getTransactionsForAddress.yaml
+++ b/zh/openapi/rpc-http/getTransactionsForAddress.yaml
@@ -309,6 +309,10 @@ paths:
                                   type: integer
                                   description: 包含交易的区块所在的槽。
                                   example: 1054
+                                transactionIndex:
+                                  type: integer
+                                  description: 交易在其区块内的从零开始的索引。用于确定区块内的交易顺序。
+                                  example: 42
                                 err:
                                   oneOf:
                                     - type: object
@@ -352,6 +356,10 @@ paths:
                                   type: integer
                                   description: 包含交易的区块的插槽。
                                   example: 1054
+                                transactionIndex:
+                                  type: integer
+                                  description: 交易在其区块内的从零开始的索引。用于确定区块内的交易顺序。
+                                  example: 42
                                 transaction:
                                   type: object
                                   description: 根据所选编码编码或解析的交易对象。
@@ -384,12 +392,14 @@ paths:
                       data:
                         - signature: "5h6xBEauJ3PK6SWCZ1PGjBvj8vDdWG3KpwATGy1ARAXFSDwt8GFXM7W5Ncn16wmqokgpiKRLuS83KUxyZyv2sUYv"
                           slot: 1054
+                          transactionIndex: 42
                           err: null
                           memo: null
                           blockTime: 1641038400
                           confirmationStatus: "已完成"
                         - signature: "kwjd820slPK6SWCZ1PGjBvj8vDdWG3KpwATGy1ARAXFSDwt8GFXM7W5Ncn16wmqokgpiKRLuS83KUxyZyv2sUYv"
                           slot: 1055
+                          transactionIndex: 15
                           err: null
                           memo: null
                           blockTime: 1641038460
@@ -403,6 +413,7 @@ paths:
                     result:
                       data:
                         - slot: 1054
+                          transactionIndex: 42
                           transaction:
                             signatures:
                               - "5h6xBEauJ3PK6SWCZ1PGjBvj8vDdWG3KpwATGy1ARAXFSDwt8GFXM7W5Ncn16wmqokgpiKRLuS83KUxyZyv2sUYv"

--- a/zh/rpc/gettransactionsforaddress.mdx
+++ b/zh/rpc/gettransactionsforaddress.mdx
@@ -241,6 +241,7 @@ description: 了解如何使用此 Helius 独有的 RPC 方法，通过高级过
           {
             "signature": "5h6xBEauJ3PK6SWCZ1PGjBvj8vDdWG3KpwATGy1ARAXFSDwt8GFXM7W5Ncn16wmqokgpiKRLuS83KUxyZyv2sUYv",
             "slot": 1054,
+            "transactionIndex": 42,
             "err": null,
             "memo": null,
             "blockTime": 1641038400,
@@ -258,12 +259,14 @@ description: 了解如何使用此 Helius 独有的 RPC 方法，通过高级过
 
     ```json
     {
-      "jsonrpc": "2.0", 
+      "jsonrpc": "2.0",
       "id": 1,
       "result": {
         "data": [
           {
             "slot": 1054,
+            "transactionIndex": 42,
+            "blockTime": 1641038400,
             "transaction": {
               "signatures": ["5h6xBEauJ3PK6SWCZ1PGjBvj8vDdWG3KpwATGy1ARAXFSDwt8GFXM7W5Ncn16wmqokgpiKRLuS83KUxyZyv2sUYv"],
               "message": {
@@ -287,6 +290,25 @@ description: 了解如何使用此 Helius 独有的 RPC 方法，通过高级过
 
   </Tab>
 </Tabs>
+
+### 响应字段
+
+| 字段 | 类型 | 描述 |
+|------|------|------|
+| `signature` | string | 交易签名（base-58 编码）。仅在签名模式下返回。 |
+| `slot` | number | 包含此交易的区块所在的槽。 |
+| `transactionIndex` | number | 交易在其区块内的从零开始的索引。用于交易排序和区块重建。 |
+| `blockTime` | number \| null | 估计的生产时间，以 Unix 时间戳表示（自纪元以来的秒数）。 |
+| `err` | object \| null | 如果交易失败则返回错误，成功则为 null。仅在签名模式下返回。 |
+| `memo` | string \| null | 与交易相关的备注。仅在签名模式下返回。 |
+| `confirmationStatus` | string | 交易的集群确认状态。仅在签名模式下返回。 |
+| `transaction` | object | 完整交易数据。仅在完整模式下返回。 |
+| `meta` | object | 交易状态元数据。仅在完整模式下返回。 |
+| `paginationToken` | string \| null | 获取下一页的令牌，如果没有更多结果则为 null。 |
+
+<Note>
+`transactionIndex` 字段是 `getTransactionsForAddress` 独有的。其他类似的端点如 `getSignaturesForAddress`、`getTransaction` 和 `getTransactions` 不包含此字段。
+</Note>
 
 ---
 


### PR DESCRIPTION
# Summary                                                                                                                                    
                                                                                                                                             
  Documents the new transactionIndex field in the getTransactionsForAddress RPC endpoint response. This field provides the zero-based index of a transaction within its block, which is useful for determining transaction ordering and block reconstruction.
                                                                                                                                             
 # Changes                                                                                                                                    
                                                                                                                                             
  - Added transactionIndex field to OpenAPI schema for both signature and full transaction response modes                                    
  - Updated response examples to include the new field                                                                                       
  - Added a "Response Fields" reference table documenting all response fields                                                                
  - Added a note clarifying that transactionIndex is exclusive to this endpoint (not available in getSignaturesForAddress, getTransaction, etc.)
  - Includes Chinese (zh) translations for all updates 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds documentation for the new transactionIndex field to getTransactionsForAddress, updating OpenAPI schemas, examples, and reference docs (EN/zh).
> 
> - **OpenAPI**:
>   - Add `transactionIndex` to `getTransactionsForAddress` response schemas for both "signatures" and "full" modes in `openapi/rpc-http/getTransactionsForAddress.yaml` and `zh/openapi/rpc-http/getTransactionsForAddress.yaml`.
>   - Update response examples to include `transactionIndex` (and retain `blockTime`, etc.).
> - **Docs**:
>   - Update examples in `rpc/gettransactionsforaddress.mdx` and `zh/rpc/gettransactionsforaddress.mdx` to show `transactionIndex` in both response modes.
>   - Add a "Response Fields" table documenting `transactionIndex` and other fields; note that `transactionIndex` is exclusive to `getTransactionsForAddress`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8446cc8ddb825727e48d54a01abcded9e6fac0ef. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->