### PR TITLE
Add transactionIndex to Example Notifications

### DIFF
--- a/enhanced-websockets/transaction-subscribe.mdx
+++ b/enhanced-websockets/transaction-subscribe.mdx
@@ -162,7 +162,8 @@ ws.on('close', function close() {
                 }
             },
             "signature": "5moMXe6VW7L7aQZskcAkKGQ1y19qqUT1teQKBNAAmipzdxdqVLAdG47WrsByFYNJSAGa9TByv15oygnqYvP6Hn2p",
-            "slot": 224341380
+            "slot": 224341380,
+            "transactionIndex": 42
         }
     }
 }

--- a/laserstream/websocket.mdx
+++ b/laserstream/websocket.mdx
@@ -261,7 +261,8 @@ You can include up to 50,000 addresses in the accountsInclude, accountExclude an
                 }
             },
             "signature": "5moMXe6VW7L7aQZskcAkKGQ1y19qqUT1teQKBNAAmipzdxdqVLAdG47WrsByFYNJSAGa9TByv15oygnqYvP6Hn2p",
-            "slot": 224341380
+            "slot": 224341380,
+            "transactionIndex": 42
         }
     }
 }

--- a/zh/enhanced-websockets/transaction-subscribe.mdx
+++ b/zh/enhanced-websockets/transaction-subscribe.mdx
@@ -164,7 +164,8 @@ ws.on('close', function close() {
                 }
             },
             "signature": "5moMXe6VW7L7aQZskcAkKGQ1y19qqUT1teQKBNAAmipzdxdqVLAdG47WrsByFYNJSAGa9TByv15oygnqYvP6Hn2p",
-            "slot": 224341380
+            "slot": 224341380,
+            "transactionIndex": 42
         }
     }
 }

--- a/zh/laserstream/websocket.mdx
+++ b/zh/laserstream/websocket.mdx
@@ -259,7 +259,8 @@ node index.js
                 }
             },
             "signature": "5moMXe6VW7L7aQZskcAkKGQ1y19qqUT1teQKBNAAmipzdxdqVLAdG47WrsByFYNJSAGa9TByv15oygnqYvP6Hn2p",
-            "slot": 224341380
+            "slot": 224341380,
+            "transactionIndex": 42
         }
     }
 }


### PR DESCRIPTION
We don't explain in our docs what each field in the notifications for `transactionSubscribe` is, so this change should be sufficient. 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates example `transactionNotification` payloads to include `transactionIndex` alongside `slot` for clarity on intra-slot ordering.
> 
> - Added `transactionIndex` to examples in `enhanced-websockets/transaction-subscribe.mdx`, `laserstream/websocket.mdx`, and their Chinese counterparts under `zh/`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 091aa7b7911cf935674cb0bf17cf24ecff79fb35. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->