### PR TITLE
Fix zh links in docs.json

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -802,16 +802,19 @@
                 "pages": [
                   "zh/getting-data",
                   "zh/rpc/gettransactionsforaddress",
-                  {
-                    "group": "历史数据",
-                    "pages": [
-                      "zh/rpc/historical-data"
-                    ]
-                  },
+                  "zh/rpc/historical-data",
+                  "zh/rpc/how-to-index-solana-data",
                   "zh/das/get-tokens",
                   "zh/das/get-nfts",
                   "zh/das/search",
-                  "zh/enhanced-transactions",
+                  {
+                    "group": "增强型交易 API",
+                    "pages": [
+                      "zh/enhanced-transactions/overview",
+                      "zh/enhanced-transactions/parse-transactions",
+                      "zh/enhanced-transactions/transaction-history"
+                    ]
+                  },
                   {
                     "group": "数字资产标准 (DAS)",
                     "pages": [
@@ -819,7 +822,8 @@
                       "zh/das/fungible-token-extension",
                       "zh/das/pagination"
                     ]
-                  }
+                  },
+                  "zh/rpc/managed-backfill"
                 ]
               },
               {
@@ -1021,7 +1025,7 @@
                     "group": "增强型交易",
                     "icon": "receipt",
                     "pages": [
-                      "zh/api-reference/enhanced-transactions",
+                      "zh/api-reference/enhanced-transactions/overview",
                       "zh/api-reference/enhanced-transactions/gettransactions",
                       "zh/api-reference/enhanced-transactions/gettransactionsbyaddress"
                     ]


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Updates `docs.json` to correct and expand Chinese (`zh`) navigation.
> 
> - Adds `zh/rpc/gettransactionsforaddress`, `zh/rpc/historical-data`, `zh/rpc/how-to-index-solana-data`, and `zh/rpc/managed-backfill` under `获取数据`
> - Replaces single `zh/enhanced-transactions` entry with grouped `增强型交易 API` pages: `overview`, `parse-transactions`, `transaction-history`
> - Adds `zh/api-reference/rpc/http/gettransactionsforaddress` and points Enhanced Transactions API reference to `zh/api-reference/enhanced-transactions/overview`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 068b16231511137293c3bfdb4c89f1d209ef8f75. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->