### PR TITLE
Change cache for price_info in getAsset from 60 to 600

### DIFF
--- a/api-reference/das/getasset.mdx
+++ b/api-reference/das/getasset.mdx
@@ -6,7 +6,7 @@ openapi: "/openapi/das-api/getAsset.yaml POST /"
 ## Price Data Caching
 
 <Warning>
-Price data returned by getAsset is cached and may not be fresh. The price information has a 60-second cache, meaning the data can be up to 60 seconds old.
+Price data returned by getAsset is cached and may not be fresh. The price information has a 600-second cache, meaning the data can be up to 600 seconds old.
 </Warning>
 
 Price data is available for the top 10k tokens by 24h volume and can be found in the `token_info.price_info` section of the response. For applications requiring real-time pricing, consider implementing additional validation.

--- a/das/get-nfts.mdx
+++ b/das/get-nfts.mdx
@@ -24,7 +24,7 @@ The Helius Digital Asset Standard (DAS) API provides powerful tools for reading 
 ## Price Data for Tokens
 
 <Warning>
-Price data returned by getAsset is cached and may not be fresh. The price information has a 60-second cache, meaning the data can be up to 60 seconds old.
+Price data returned by getAsset is cached and may not be fresh. The price information has a 600-second cache, meaning the data can be up to 600 seconds old.
 </Warning>
 
 ```typescript


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Updates docs to reflect longer caching for `getAsset` price data.
> 
> - Changes `price_info` cache duration from 60s to 600s in `api-reference/das/getasset.mdx` and `das/get-nfts.mdx` warnings
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ee18907b4557837994cc53b3ebc1b2f8f7fdb2a2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->