### PR TITLE
feat(val-api): Add Stake Accounts Endpoint

### DIFF
--- a/validator-reporting/index.mdx
+++ b/validator-reporting/index.mdx
@@ -108,7 +108,7 @@ Example: `he1iusunGwqrNtafDtLdhsUQDFvo13z9sUa36PauBtk`
     Get rewards for multiple stake accounts:
 
     ```bash
-    curl -X POST "https://mainnet.helius-rpc.com/stake-accounts/metrics?api-key=YOUR_API_KEY" \
+    curl -X POST "https://mainnet.helius-rpc.com/validators/stake-accounts/metrics?api-key=YOUR_API_KEY" \
       -H "Content-Type: application/json" \
       -d '{
         "stake_accounts": [

--- a/validator-reporting/stake-accounts.mdx
+++ b/validator-reporting/stake-accounts.mdx
@@ -10,7 +10,7 @@ description: "Retrieve staking rewards and MEV rewards for a list of stake accou
 ## Endpoint
 
 ```
-POST https://mainnet.helius-rpc.com/stake-accounts/metrics
+POST https://mainnet.helius-rpc.com/validators/stake-accounts/metrics
 ```
 
 ## Description
@@ -88,7 +88,7 @@ The endpoint automatically distinguishes between:
 <CodeGroup>
 
 ```bash cURL - 30 Day Period
-curl -X POST "https://mainnet.helius-rpc.com/stake-accounts/metrics?api-key=YOUR_API_KEY" \
+curl -X POST "https://mainnet.helius-rpc.com/validators/stake-accounts/metrics?api-key=YOUR_API_KEY" \
   -H "Content-Type: application/json" \
   -d '{
     "stake_accounts": [
@@ -100,7 +100,7 @@ curl -X POST "https://mainnet.helius-rpc.com/stake-accounts/metrics?api-key=YOUR
 ```
 
 ```bash cURL - Custom Epoch Range
-curl -X POST "https://mainnet.helius-rpc.com/stake-accounts/metrics?api-key=YOUR_API_KEY" \
+curl -X POST "https://mainnet.helius-rpc.com/validators/stake-accounts/metrics?api-key=YOUR_API_KEY" \
   -H "Content-Type: application/json" \
   -d '{
     "stake_accounts": [
@@ -112,7 +112,7 @@ curl -X POST "https://mainnet.helius-rpc.com/stake-accounts/metrics?api-key=YOUR
 ```
 
 ```bash cURL - With Per-Epoch Breakdown
-curl -X POST "https://mainnet.helius-rpc.com/stake-accounts/metrics?api-key=YOUR_API_KEY" \
+curl -X POST "https://mainnet.helius-rpc.com/validators/stake-accounts/metrics?api-key=YOUR_API_KEY" \
   -H "Content-Type: application/json" \
   -d '{
     "stake_accounts": [
@@ -130,7 +130,7 @@ const getStakeAccountMetrics = async (
   options = {}
 ) => {
   const baseUrl = 'https://mainnet.helius-rpc.com';
-  const url = `${baseUrl}/stake-accounts/metrics?api-key=${apiKey}`;
+  const url = `${baseUrl}/validators/stake-accounts/metrics?api-key=${apiKey}`;
 
   const body = {
     stake_accounts: stakeAccounts,
@@ -204,7 +204,7 @@ def get_stake_account_metrics(
     - group_by_epoch: bool
     """
     base_url = "https://mainnet.helius-rpc.com"
-    url = f"{base_url}/stake-accounts/metrics"
+    url = f"{base_url}/validators/stake-accounts/metrics"
     params = {"api-key": api_key}
 
     payload = {


### PR DESCRIPTION
This PR aims to add the new stake accounts endpoint to the validator, which surfaces per-account stake and MEV rewards as well as other information like which validator the stake account was delegated to during the period queried 

Like the rest of the validator API, this new page is unlinked from the rest of the docs

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces comprehensive docs for `POST /validators/stake-accounts/metrics` to fetch staking (inflation) and MEV rewards for multiple stake/vote accounts.
> 
> - New `validator-reporting/stake-accounts.mdx` with endpoint description, request body (`stake_accounts`, `period` or `start_epoch`/`end_epoch`, `group_by_epoch`), cURL/JavaScript/Python examples, detailed response schema (aggregated totals and optional per-epoch `epoch_rewards`), account type detection, error responses, notes, use cases, and related links
> - Updates `validator-reporting/index.mdx` to add a `Stake Account Metrics` card and a Quick Start tab demonstrating a POST request
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9fe278250c97809212c790e255c385b2b8927eb2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->