### PR TITLE
gTFA API reference: add parameters

### DIFF
--- a/api-reference/rpc/http/gettransactionsforaddress.mdx
+++ b/api-reference/rpc/http/gettransactionsforaddress.mdx
@@ -6,3 +6,78 @@ description: "Enhanced transaction history API with powerful filtering, sorting,
 "og:description": "Get a free RPC and explore the getTransactionsForAddress RPC Method. Advanced transaction history queries with filtering, sorting, and pagination. Includes request parameters, response examples, code snippets, and in-browser testing for both Solana Mainnet and Devnet."
 openapi: "/openapi/rpc-http/getTransactionsForAddress.yaml POST /"
 ---
+
+## Request Parameters
+
+<ParamField body="address" type="string" required>
+  Base-58 encoded public key of the account to query transaction history for
+</ParamField>
+
+<ParamField body="transactionDetails" type="string" default="signatures">
+  Level of transaction detail to return:
+  - `signatures`: Basic signature info (faster)
+  - `full`: Complete transaction data (eliminates need for getTransaction calls, requires limit ≤ 100)
+</ParamField>
+
+<ParamField body="sortOrder" type="string" default="desc">
+  Sort order for results:
+  - `desc`: Newest first (default)
+  - `asc`: Oldest first (chronological, great for historical analysis)
+</ParamField>
+
+<ParamField body="limit" type="number" default="1000">
+  Maximum transactions to return:
+  - Up to 1000 when `transactionDetails: "signatures"`
+  - Up to 100 when `transactionDetails: "full"`
+</ParamField>
+
+<ParamField body="paginationToken" type="string">
+  Pagination token from previous response (format: `"slot:position"`)
+</ParamField>
+
+<ParamField body="commitment" type="string" default="finalized">
+  Commitment level: `finalized`, `confirmed`, or `processed`
+</ParamField>
+
+<ParamField body="filters" type="object">
+  Advanced filtering options for narrowing down results.
+</ParamField>
+
+<ParamField body="filters.slot" type="object">
+  Filter by slot number using comparison operators: `gte`, `gt`, `lte`, `lt`
+  
+  Example: `{ "slot": { "gte": 1000, "lte": 2000 } }`
+</ParamField>
+
+<ParamField body="filters.blockTime" type="object">
+  Filter by Unix timestamp using comparison operators: `gte`, `gt`, `lte`, `lt`, `eq`
+  
+  Example: `{ "blockTime": { "gte": 1640995200, "lte": 1641081600 } }`
+</ParamField>
+
+<ParamField body="filters.signature" type="object">
+  Filter by transaction signature using comparison operators: `gte`, `gt`, `lte`, `lt`
+  
+  Example: `{ "signature": { "lt": "SIGNATURE_STRING" } }`
+</ParamField>
+
+<ParamField body="filters.status" type="string">
+  Filter by transaction success/failure status:
+  - `succeeded`: Only successful transactions
+  - `failed`: Only failed transactions
+  - `any`: Both successful and failed (default)
+  
+  Example: `{ "status": "succeeded" }`
+</ParamField>
+
+<ParamField body="encoding" type="string">
+  Encoding format for transaction data (only applies when `transactionDetails: "full"`). Same as `getTransaction` API. Options: `json`, `jsonParsed`, `base64`, `base58`
+</ParamField>
+
+<ParamField body="maxSupportedTransactionVersion" type="number">
+  Set the max transaction version to return. If omitted, only legacy transactions will be returned. Set to `0` to include all versioned transactions.
+</ParamField>
+
+<ParamField body="minContextSlot" type="number">
+  The minimum slot that the request can be evaluated at
+</ParamField>


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Expands the `getTransactionsForAddress` RPC reference with a concise Request Parameters section.
> 
> - Documents `address`, `transactionDetails`, `sortOrder`, `limit`, `paginationToken`, `commitment`
> - Adds advanced `filters` support (`slot`, `blockTime`, `signature`, `status`)
> - Notes `encoding` options for full details and `maxSupportedTransactionVersion`
> - Includes `minContextSlot` handling and constraints (e.g., `limit` caps for `full` details)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3942f390adf524b4f6a244c7a4ccb67eef6c238c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->