### PR TITLE
docs: remove processed commitment from getTransactionsForAddress and getSignaturesForAddress

### DIFF
--- a/api-reference/rpc/http/gettransactionsforaddress.mdx
+++ b/api-reference/rpc/http/gettransactionsforaddress.mdx
@@ -36,7 +36,7 @@ openapi: "/openapi/rpc-http/getTransactionsForAddress.yaml POST /"
 </ParamField>
 
 <ParamField body="commitment" type="string" default="finalized">
-  Commitment level: `finalized`, `confirmed`, or `processed`
+  Commitment level: `finalized` or `confirmed`. The `processed` commitment is not supported.
 </ParamField>
 
 <ParamField body="filters" type="object">

--- a/openapi/rpc-http/getSignaturesForAddress.yaml
+++ b/openapi/rpc-http/getSignaturesForAddress.yaml
@@ -106,11 +106,10 @@ paths:
                         properties:
                           commitment:
                             type: string
-                            description: The commitment level for the request.
+                            description: The commitment level for the request. The `processed` commitment is not supported.
                             enum:
                               - confirmed
                               - finalized
-                              - processed
                             example: finalized
                           minContextSlot:
                             type: integer

--- a/openapi/rpc-http/getTransactionsForAddress.yaml
+++ b/openapi/rpc-http/getTransactionsForAddress.yaml
@@ -128,11 +128,10 @@ paths:
                           example: desc
                         commitment:
                           type: string
-                          description: The commitment level for the request.
+                          description: The commitment level for the request. The `processed` commitment is not supported.
                           enum:
                             - confirmed
                             - finalized
-                            - processed
                           default: finalized
                           example: finalized
                         minContextSlot:

--- a/rpc/gettransactionsforaddress.mdx
+++ b/rpc/gettransactionsforaddress.mdx
@@ -131,7 +131,7 @@ The API also supports **Audit & Compliance** workflows by generating transaction
 </ParamField>
 
 <ParamField body="commitment" type="string" default="finalized">
-  Commitment level: `finalized`, `confirmed`, or `processed`
+  Commitment level: `finalized` or `confirmed`. The `processed` commitment is not supported.
 </ParamField>
 
 <ParamField body="filters" type="object">

--- a/rpc/guides/getsignaturesforaddress.mdx
+++ b/rpc/guides/getsignaturesforaddress.mdx
@@ -24,7 +24,7 @@ The [`getSignaturesForAddress`](https://www.helius.dev/docs/api-reference/rpc/ht
     *   **`limit`** (`number`, optional): The maximum number of signatures to return. The default is 1000, and the maximum allowed is 1000.
     *   **`before`** (`string`, optional): A base-58 encoded transaction signature. If provided, the query will start searching for transactions before this signature.
     *   **`until`** (`string`, optional): A base-58 encoded transaction signature. If provided, the query will search for transactions until this signature is reached (exclusive).
-    *   **`commitment`** (`string`, optional): Specifies the [commitment level](https://www.helius.dev/blog/solana-commitment-levels) to use for the query. Supported values are `finalized`, `confirmed`, or `processed`. If omitted, the default commitment of the RPC node is used (usually `finalized`).
+    *   **`commitment`** (`string`, optional): Specifies the [commitment level](https://www.helius.dev/blog/solana-commitment-levels) to use for the query. Supported values are `finalized` or `confirmed`. The `processed` commitment is not supported. If omitted, the default commitment of the RPC node is used (usually `finalized`).
     *   **`minContextSlot`** (`number`, optional): The minimum slot that the request can be evaluated at. This is not a filter on historical transactions but sets the minimum slot for the node's context.
 
 <Warning>


### PR DESCRIPTION
These methods do not support the `processed` commitment level. Updated documentation to reflect that only `finalized` and `confirmed` are supported.

https://www.helius.dev/docs/rpc/gettransactionsforaddress
https://www.helius.dev/docs/api-reference/rpc/http/gettransactionsforaddress
https://www.helius.dev/docs/rpc/guides/getsignaturesforaddress
https://www.helius.dev/docs/api-reference/rpc/http/getsignaturesforaddress

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Clarifies commitment-level support for transaction history RPC docs and OpenAPI specs.
> 
> - Updates `getTransactionsForAddress` and `getSignaturesForAddress` docs and OpenAPI to state only `finalized` and `confirmed` are supported; `processed` is not supported
> - Removes `processed` from `commitment` enums in `openapi/rpc-http/getTransactionsForAddress.yaml` and `getSignaturesForAddress.yaml`, and updates descriptions in related MDX guides (`api-reference/rpc/http/gettransactionsforaddress.mdx`, `rpc/gettransactionsforaddress.mdx`, `rpc/guides/getsignaturesforaddress.mdx`)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 567963e85e56c10bf8cb9be7bc65b8d26d84a7ca. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->